### PR TITLE
Fix glob option injection vulnerability

### DIFF
--- a/SPECS-EXTENDED/jsoup/generate-tarball.sh
+++ b/SPECS-EXTENDED/jsoup/generate-tarball.sh
@@ -14,7 +14,7 @@ tar xf "../${name}-${version}.orig.tar.gz"
 
 # CLEAN TARBALL
 # contains scraped news articles (non-free)
-rm -r */src/test/resources
+rm -r -- */src/test/resources
 
 tar czf "../${name}-${version}.tar.gz" *
 cd ..


### PR DESCRIPTION
<!-- dd-meta {"pullId":"d9fbebee-f2ec-4b8e-b482-ec31c65b5247","source":"chat","resourceId":"10d242be-428f-4939-bf0f-85e4871bb87c","workflowId":"d9c9ae3e-034b-41f1-8b4d-abc04684add4","codeChangeId":"d9c9ae3e-034b-41f1-8b4d-abc04684add4","sourceType":"code_security_sast"} -->
###### Summary

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/d82620fbbdc0f7d0fc9592e0bd393a38?panel_event_id=AwAAAZ8ccLSu6Q5_IAAAABhBWjhjY0xTdUFBQllTSEdXZngySDhtOTAAAAAkZjE5ZjFjN2EtMzk2MS00NjRhLTkwMzUtMzgyOTRkMWM5ZjIzAAAZEw&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22ZDgyNjIwZmJiZGMwZjdkMGZjOTU5MmUwYmQzOTNhMzh-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22+%22Glob+may+expand+to+names+starting+with+-+and+be+parsed+as+options%3B+use+.%2F%2A+or+--+before+the+glob%22)

Fixes a critical SAST vulnerability where glob patterns could be interpreted as command-line options to the rm command.

###### Change Log
- Fixed glob option injection vulnerability in SPECS-EXTENDED/jsoup/generate-tarball.sh:17
- Added `--` before glob pattern in `rm -r */src/test/resources` to prevent option injection

###### Does this affect the toolchain?
NO

###### Test Methodology
- Verified the fix addresses the bash-security/prevent-option-injection-via-globs rule
- Confirmed the change is minimal and targeted

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/10d242be-428f-4939-bf0f-85e4871bb87c)

Comment @datadog to request changes