### PR TITLE
Fix glob vulnerability in jdom2 script

### DIFF
--- a/SPECS-EXTENDED/jdom2/generate-tarball.sh
+++ b/SPECS-EXTENDED/jdom2/generate-tarball.sh
@@ -13,7 +13,7 @@ pushd tarball-tmp
 tar xf "../${name}-${version}.orig.tar.gz"
 
 # CLEAN TARBALL
-rm -r */lib */*/lib
+rm -r -- */lib */*/lib
 find -name '*.jar' -delete
 find -name '*.class' -delete
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"d337d82a-31a2-4416-9e98-853a32e04a67","source":"chat","resourceId":"b5bb679a-a6a6-4217-977e-c3792d6f08ed","workflowId":"11de797d-5dba-49ee-993f-7cb042901a09","codeChangeId":"11de797d-5dba-49ee-993f-7cb042901a09","sourceType":"code_security_sast"} -->
## Summary

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/f64b238572d563d43fce37378c97f221?panel_event_id=AwAAAZ8dQsCDL_zU_QAAABhBWjhkUXNDREFBQ1VkdWw1UXNxVThhOVIAAAAkZjE5ZjFkNDgtMzc0Ny00YTI4LTk5YjgtYWNjM2I5MmNkYzQwAABAmw&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22ZjY0YjIzODU3MmQ1NjNkNDNmY2UzNzM3OGM5N2YyMjF-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22+%22Glob+may+expand+to+names+starting+with+-+and+be+parsed+as+options%3B+use+.%2F%2A+or+--+before+the+glob%22)

Fixes critical SAST vulnerability where glob patterns could be interpreted as command options.

## Changes
- Added `--` flag to `rm -r` command to prevent glob patterns from being interpreted as options
- Changed `rm -r */lib */*/lib` to `rm -r -- */lib */*/lib` in SPECS-EXTENDED/jdom2/generate-tarball.sh

## Testing
- Verified script syntax is valid
- Tested fix prevents option injection
- Confirmed functionality maintained

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/b5bb679a-a6a6-4217-977e-c3792d6f08ed)

Comment @datadog to request changes