### PR TITLE
Fix glob vulnerability in download-packages.sh

### DIFF
--- a/toolkit/scripts/download-packages.sh
+++ b/toolkit/scripts/download-packages.sh
@@ -21,11 +21,11 @@ function make_tarball {
 
     for package_type in $packages_types; do
         mkdir -p RPMS/$package_type
-        mv *.$package_type.rpm RPMS/$package_type/
+        mv -- *.$package_type.rpm RPMS/$package_type/
     done
 
     mkdir -p RPMS/noarch
-    mv *.noarch.rpm RPMS/noarch/
+    mv -- *.noarch.rpm RPMS/noarch/
 
     echo "-- Packaging into a tarball..."
     tar --remove-files -czvf $archive_name RPMS


### PR DESCRIPTION
<!-- dd-meta {"pullId":"2c996b10-1907-40b2-ae0a-47bdeccfa46d","source":"chat","resourceId":"b167f088-0096-4063-90be-c47ad3c33ca9","workflowId":"3c1143e8-b653-4f0e-9254-dedfb775ebc1","codeChangeId":"3c1143e8-b653-4f0e-9254-dedfb775ebc1","sourceType":"code_security_sast"} -->
## Summary

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/102ba457ddc819f2f3c16374f23fa240?panel_event_id=AwAAAZ8dND317W5iVAAAABhBWjhkTkQzMUFBQ0tUWjN4ZzFteGM3dUsAAAAkZjE5ZjFkM2EtN2MzYi00MGY1LWFjMTYtZTRkNWRmMGQ2NjY2AABELg&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22MTAyYmE0NTdkZGM4MTlmMmYzYzE2Mzc0ZjIzZmEyNDB-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22+%22Glob+may+expand+to+names+starting+with+-+and+be+parsed+as+options%3B+use+.%2F%2A+or+--+before+the+glob%22)

Fixes a critical SAST vulnerability where glob patterns in `mv` commands could be interpreted as command-line options if filenames start with '-'.

## Changes
- Added `--` before glob patterns in `mv` commands on lines 24 and 28
- Changed `mv *.$package_type.rpm RPMS/$package_type/` to `mv -- *.$package_type.rpm RPMS/$package_type/`
- Changed `mv *.noarch.rpm RPMS/noarch/` to `mv -- *.noarch.rpm RPMS/noarch/`

## Testing
- Verified script syntax is valid with `bash -n`
- Confirmed no other similar vulnerabilities exist in the file
- Fix follows security best practices for preventing option injection via globs

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/b167f088-0096-4063-90be-c47ad3c33ca9)

Comment @datadog to request changes