### PR TITLE
Fix jsoup glob expansion vulnerability

### DIFF
--- a/SPECS-EXTENDED/jsoup/generate-tarball.sh
+++ b/SPECS-EXTENDED/jsoup/generate-tarball.sh
@@ -16,6 +16,6 @@ tar xf "../${name}-${version}.orig.tar.gz"
 # contains scraped news articles (non-free)
 rm -r */src/test/resources
 
-tar czf "../${name}-${version}.tar.gz" *
+tar czf "../${name}-${version}.tar.gz" -- *
 cd ..
 rm -r tarball-tmp "${name}-${version}.orig.tar.gz"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"56091370-531b-4a4e-9042-df2e9fc6130f","source":"chat","resourceId":"aab7f0b6-e00a-449a-a74a-0c6447b86007","workflowId":"fcb84580-fd98-4ab0-9b9e-c12827d302d0","codeChangeId":"fcb84580-fd98-4ab0-9b9e-c12827d302d0","sourceType":"code_security_sast"} -->
## Summary

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/e839a126e3e443b98e00dc441737086b?panel_event_id=AwAAAZ8cwO76iUvpCwAAABhBWjhjd083NkFBQXIxSzlpWDd2UGwzelAAAAAkZjE5ZjFjY2MtOWVkMi00YTc3LWE2ZTgtZjNmM2ZiMGI3OTZkAABIyw&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22ZTgzOWExMjZlM2U0NDNiOThlMDBkYzQ0MTczNzA4NmJ-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22+%22Glob+may+expand+to+names+starting+with+-+and+be+parsed+as+options%3B+use+.%2F%2A+or+--+before+the+glob%22)

Fixes a critical SAST vulnerability where glob expansion could interpret files starting with hyphens as tar options, potentially leading to command injection.

## Changes
- Fixed line 19 in SPECS-EXTENDED/jsoup/generate-tarball.sh: changed `tar czf "../${name}-${version}.tar.gz" *` to `tar czf "../${name}-${version}.tar.gz" -- *`
- Added `--` prefix before glob to prevent option injection

## Testing
- Verified the fix prevents files starting with hyphens from being interpreted as tar options
- Tested that normal file archiving still works correctly
- Confirmed the vulnerability would cause tar command failure without the fix

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/aab7f0b6-e00a-449a-a74a-0c6447b86007)

Comment @datadog to request changes