### PR TITLE
Fix glob vulnerability in generate-tarball.sh

### DIFF
--- a/SPECS/objectweb-asm/generate-tarball.sh
+++ b/SPECS/objectweb-asm/generate-tarball.sh
@@ -20,6 +20,6 @@ mv asm-${gittag}-* ${name}-${version}
 # Remove all jar files
 find -name '*.jar' -delete
 
-tar cJf "../${name}-${version}.tar.xz" *
+tar cJf "../${name}-${version}.tar.xz" -- *
 cd ..
 rm -r tarball-tmp "${name}-${version}.orig.tar.gz"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"56023b59-9c5b-4037-8f0b-097064b4effb","source":"chat","resourceId":"95765745-ec27-4bf7-8881-7e17159dcdb0","workflowId":"da0c72d9-724a-44dd-a973-4eaa06b704be","codeChangeId":"da0c72d9-724a-44dd-a973-4eaa06b704be","sourceType":"code_security_sast"} -->
## Summary

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/81797201f72781f518ceaaae802a7e5d?panel_event_id=AwAAAZ8dFq6GbCIbQQAAABhBWjhkRnE2R0FBRDRaM0J1Y0VmRG1GNzUAAAAkZjE5ZjFkMWYtMDI0NC00Njg3LTgwMWMtZjI3YjUyZWFlNmFhAABhUw&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22ODE3OTcyMDFmNzI3ODFmNTE4Y2VhYWFlODAyYTdlNWR-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22+%22Glob+may+expand+to+names+starting+with+-+and+be+parsed+as+options%3B+use+.%2F%2A+or+--+before+the+glob%22)

Fixes a critical SAST vulnerability where glob patterns could expand to filenames starting with hyphens and be parsed as command-line options to tar.

## Changes
- Fixed `SPECS/objectweb-asm/generate-tarball.sh:23` by adding `--` before the glob pattern `*`
- Changed `tar cJf "../${name}-${version}.tar.xz" *` to `tar cJf "../${name}-${version}.tar.xz" -- *`

## Testing
- Verified script syntax is valid with `bash -n`
- Tested that the fixed command works correctly with files that have hyphen-prefixed names
- Confirmed the fix resolves the bash-security/prevent-option-injection-via-globs vulnerability

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/95765745-ec27-4bf7-8881-7e17159dcdb0)

Comment @datadog to request changes