### PR TITLE
Fix glob option injection vulnerability

### DIFF
--- a/SPECS-EXTENDED/jsoup/generate-tarball.sh
+++ b/SPECS-EXTENDED/jsoup/generate-tarball.sh
@@ -16,6 +16,6 @@ tar xf "../${name}-${version}.orig.tar.gz"
 # contains scraped news articles (non-free)
 rm -r */src/test/resources
 
-tar czf "../${name}-${version}.tar.gz" *
+tar czf "../${name}-${version}.tar.gz" -- *
 cd ..
 rm -r tarball-tmp "${name}-${version}.orig.tar.gz"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"f93d06d9-c30f-496f-867f-4618d9058dc3","source":"chat","resourceId":"1a884135-8546-4ace-8e50-756732333e0e","workflowId":"e83ce4a6-f129-4eef-8afe-37cf638246b0","codeChangeId":"e83ce4a6-f129-4eef-8afe-37cf638246b0","sourceType":"code_security_sast"} -->
###### Summary

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/e839a126e3e443b98e00dc441737086b?panel_event_id=AwAAAZ8cwO76iUvpCwAAABhBWjhjd083NkFBQXIxSzlpWDd2UGwzelAAAAAkZjE5ZjFjY2MtOWVkMi00YTc3LWE2ZTgtZjNmM2ZiMGI3OTZkAABIyw&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22ZTgzOWExMjZlM2U0NDNiOThlMDBkYzQ0MTczNzA4NmJ-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22+%22Glob+may+expand+to+names+starting+with+-+and+be+parsed+as+options%3B+use+.%2F%2A+or+--+before+the+glob%22)

Fixes a critical SAST vulnerability where glob patterns could expand to filenames starting with '-' and be interpreted as tar command-line options.

###### Change Log
- Fixed glob option injection vulnerability in SPECS-EXTENDED/jsoup/generate-tarball.sh line 19
- Added `--` before glob pattern to prevent option injection
- Change: `tar czf "../${name}-${version}.tar.gz" *` → `tar czf "../${name}-${version}.tar.gz" -- *`

###### Does this affect the toolchain?
NO

###### Test Methodology
- Verified script has no syntax errors with `bash -n`
- Confirmed the fix follows security best practices for glob patterns
- Validated that the change maintains the original functionality while preventing option injection

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/1a884135-8546-4ace-8e50-756732333e0e)

Comment @datadog to request changes