### PR TITLE
Fix glob option injection vulnerability in jdom2

### DIFF
--- a/SPECS-EXTENDED/jdom2/generate-tarball.sh
+++ b/SPECS-EXTENDED/jdom2/generate-tarball.sh
@@ -13,7 +13,7 @@ pushd tarball-tmp
 tar xf "../${name}-${version}.orig.tar.gz"
 
 # CLEAN TARBALL
-rm -r */lib */*/lib
+rm -r -- */lib */*/lib
 find -name '*.jar' -delete
 find -name '*.class' -delete
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"9c1819dc-e881-4ded-87f0-2e0043606b68","source":"chat","resourceId":"7b8f2746-c745-4678-bdca-3f52138cc071","workflowId":"8780af7c-d058-4edb-88ae-46f214c65181","codeChangeId":"8780af7c-d058-4edb-88ae-46f214c65181","sourceType":"code_security_sast"} -->
## Summary

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/f64b238572d563d43fce37378c97f221?panel_event_id=AwAAAZ8dQsCDL_zU_QAAABhBWjhkUXNDREFBQ1VkdWw1UXNxVThhOVIAAAAkZjE5ZjFkNDgtMzc0Ny00YTI4LTk5YjgtYWNjM2I5MmNkYzQwAABAmw&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22ZjY0YjIzODU3MmQ1NjNkNDNmY2UzNzM3OGM5N2YyMjF-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22+%22Glob+may+expand+to+names+starting+with+-+and+be+parsed+as+options%3B+use+.%2F%2A+or+--+before+the+glob%22)

Fixes a critical SAST vulnerability where glob patterns in generate-tarball.sh could be interpreted as command options, potentially leading to unintended file deletion.

## Changes
- Modified `SPECS-EXTENDED/jdom2/generate-tarball.sh` line 16
- Added `--` before glob patterns to prevent option injection
- Changed `rm -r */lib */*/lib` to `rm -r -- */lib */*/lib`

## Testing
- Verified script syntax is valid with `bash -n`
- Tested the fix with realistic directory structures
- Confirmed that glob patterns are no longer interpreted as command options
- Verified that only intended directories are removed, not malicious ones starting with hyphens

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/7b8f2746-c745-4678-bdca-3f52138cc071)

Comment @datadog to request changes