### PR TITLE
Fix glob injection vulnerability

### DIFF
--- a/SPECS/objectweb-asm/generate-tarball.sh
+++ b/SPECS/objectweb-asm/generate-tarball.sh
@@ -20,6 +20,6 @@ mv asm-${gittag}-* ${name}-${version}
 # Remove all jar files
 find -name '*.jar' -delete
 
-tar cJf "../${name}-${version}.tar.xz" *
+tar cJf "../${name}-${version}.tar.xz" -- *
 cd ..
 rm -r tarball-tmp "${name}-${version}.orig.tar.gz"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"93c72773-f042-49e7-b1de-2c794f0f361a","source":"chat","resourceId":"ba45b0f1-7041-40cb-8c06-76afb56f4651","workflowId":"e1cbf3e1-9091-4382-8463-1c6d9427842b","codeChangeId":"e1cbf3e1-9091-4382-8463-1c6d9427842b","sourceType":"code_security_sast"} -->
###### Summary

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/81797201f72781f518ceaaae802a7e5d?panel_event_id=AwAAAZ8dFq6GbCIbQQAAABhBWjhkRnE2R0FBRDRaM0J1Y0VmRG1GNzUAAAAkZjE5ZjFkMWYtMDI0NC00Njg3LTgwMWMtZjI3YjUyZWFlNmFhAABhUw&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22ODE3OTcyMDFmNzI3ODFmNTE4Y2VhYWFlODAyYTdlNWR-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22+%22Glob+may+expand+to+names+starting+with+-+and+be+parsed+as+options%3B+use+.%2F%2A+or+--+before+the+glob%22)

Fixes a critical SAST vulnerability where glob patterns could expand to filenames starting with `-` and be interpreted as tar options, potentially causing command injection.

###### Change Log
- Fixed glob option injection vulnerability in `SPECS/objectweb-asm/generate-tarball.sh:23` by adding `--` before the `*` glob pattern

###### Does this affect the toolchain?
NO

###### Test Methodology
- The fix prevents potential command injection by ensuring glob patterns are treated as filenames rather than tar options
- The change is minimal and maintains the existing functionality while improving security

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/ba45b0f1-7041-40cb-8c06-76afb56f4651)

Comment @datadog to request changes