### PR TITLE
Fix glob option injection vulnerability

### DIFF
--- a/toolkit/scripts/download-packages.sh
+++ b/toolkit/scripts/download-packages.sh
@@ -21,11 +21,11 @@ function make_tarball {
 
     for package_type in $packages_types; do
         mkdir -p RPMS/$package_type
-        mv *.$package_type.rpm RPMS/$package_type/
+        mv -- *.$package_type.rpm RPMS/$package_type/
     done
 
     mkdir -p RPMS/noarch
-    mv *.noarch.rpm RPMS/noarch/
+    mv -- *.noarch.rpm RPMS/noarch/
 
     echo "-- Packaging into a tarball..."
     tar --remove-files -czvf $archive_name RPMS


### PR DESCRIPTION
<!-- dd-meta {"pullId":"d020ebef-0011-4231-9ea1-fee2f74ba1cd","source":"chat","resourceId":"3d805be8-d24d-4983-959b-fcd649565b2c","workflowId":"d90eb13a-61b3-40e3-85f4-eef06424ad93","codeChangeId":"d90eb13a-61b3-40e3-85f4-eef06424ad93","sourceType":"code_security_sast"} -->
###### Summary

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/102ba457ddc819f2f3c16374f23fa240?panel_event_id=AwAAAZ8dND317W5iVAAAABhBWjhkTkQzMUFBQ0tUWjN4ZzFteGM3dUsAAAAkZjE5ZjFkM2EtN2MzYi00MGY1LWFjMTYtZTRkNWRmMGQ2NjY2AABELg&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22MTAyYmE0NTdkZGM4MTlmMmYzYzE2Mzc0ZjIzZmEyNDB-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22+%22Glob+may+expand+to+names+starting+with+-+and+be+parsed+as+options%3B+use+.%2F%2A+or+--+before+the+glob%22)

Fixes a critical SAST vulnerability where glob patterns in `mv` commands could expand to filenames starting with `-` and be interpreted as options to the `mv` command.

###### Change Log
- Fixed glob option injection vulnerability in `toolkit/scripts/download-packages.sh`
- Added `--` before glob patterns on lines 24 and 28 to prevent option injection
- Changed `mv *.$package_type.rpm RPMS/$package_type/` to `mv -- *.$package_type.rpm RPMS/$package_type/`
- Changed `mv *.noarch.rpm RPMS/noarch/` to `mv -- *.noarch.rpm RPMS/noarch/`

###### Does this affect the toolchain?
NO

###### Test Methodology
- Verified the fix addresses the SAST finding for bash-security/prevent-option-injection-via-globs
- Confirmed the changes follow bash best practices for handling glob patterns

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/3d805be8-d24d-4983-959b-fcd649565b2c)

Comment @datadog to request changes