### PR TITLE
Fix command substitution vulnerability

### DIFF
--- a/toolkit/scripts/containerized-build/resources/setup_functions.sh
+++ b/toolkit/scripts/containerized-build/resources/setup_functions.sh
@@ -49,7 +49,7 @@ build_pkg() {
     local PKG=("$@")
     if [ -z "$PKG" ]; then echo "Please provide pkg name"; return; fi
     rpm -ihv /mnt/INTERMEDIATE_SRPMS/$PKG*.src.rpm
-    $(install_dependencies $PKG)
+    install_dependencies $PKG
     rpmbuild -ba $SPECS_DIR/$PKG/$PKG.spec
 }
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"71bcfcfc-71bd-43fb-80c1-904a0603629d","source":"chat","resourceId":"2105d1ac-72c4-418c-8f5e-c7c1a154288f","workflowId":"76c31e3c-740e-4578-870c-c941b66c532b","codeChangeId":"76c31e3c-740e-4578-870c-c941b66c532b","sourceType":"code_security_sast"} -->
## Summary

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/56358fd1701a0f359ef417f78f362f3c?panel_event_id=AwAAAZ8eBKcWKHBmUAAAABhBWjhlQktjV0FBQlhlbm1CVGtPZkhnMkUAAAAkZjE5ZjFlMDQtYmE3ZC00MjI5LTgwZGYtZWU3YzQ5NGIzYzc2AAAAnw&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22NTYzNThmZDE3MDFhMGYzNTllZjQxN2Y3OGYzNjJmM2N-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22+%22Do+not+use+%24%28...%29+to+run+commands.+Run+the+inner+command+directly%2C+or+use+eval+with+a+quoted+string+%28and+careful+escaping%29+only+when+you+intentionally+execute+shell+code+produced+as+text.%22)

Fixes a critical SAST vulnerability by replacing dangerous command substitution with direct function call.

## Changes
- Replaced `$(install_dependencies $PKG)` with `install_dependencies $PKG` in the `build_pkg` function
- This eliminates the risk of executing untrusted shell code from command substitution output

## Testing
The fix maintains the same functionality while removing the security vulnerability. The `install_dependencies` function was already executing commands directly and not returning any output that needed to be executed as a command.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/2105d1ac-72c4-418c-8f5e-c7c1a154288f)

Comment @datadog to request changes