### PR TITLE
Fix command substitution in setup_functions.sh

### DIFF
--- a/toolkit/scripts/containerized-build/resources/setup_functions.sh
+++ b/toolkit/scripts/containerized-build/resources/setup_functions.sh
@@ -49,7 +49,7 @@ build_pkg() {
     local PKG=("$@")
     if [ -z "$PKG" ]; then echo "Please provide pkg name"; return; fi
     rpm -ihv /mnt/INTERMEDIATE_SRPMS/$PKG*.src.rpm
-    $(install_dependencies $PKG)
+    install_dependencies $PKG
     rpmbuild -ba $SPECS_DIR/$PKG/$PKG.spec
 }
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"63a02755-1079-45cf-99e3-5fa300072128","source":"chat","resourceId":"a8d07636-a678-4a0a-8b32-5e6b4af68b79","workflowId":"db302edc-bf63-4ceb-b834-cd30f945cac0","codeChangeId":"db302edc-bf63-4ceb-b834-cd30f945cac0","sourceType":"code_security_sast"} -->
###### Summary

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/56358fd1701a0f359ef417f78f362f3c?column=score&order=desc&panel_event_id=AwAAAZ8cvms5KHBmUAAAABhBWjhjdm1zNUFBRDJlbS1jd0k2dVNQSnAAAAAkZjE5ZjFjYmUtZTFlYS00NjVmLTkwMmYtNjY2NDk2YWNjOTE2AAA6KA)

Fixes a bash security vulnerability where `$(...)` command substitution was incorrectly used to execute the output of the `install_dependencies` function. The function already executes commands internally, so the command substitution was unnecessary and potentially dangerous.

###### Change Log
- Fixed line 52 in `toolkit/scripts/containerized-build/resources/setup_functions.sh` by removing the command substitution syntax
- Changed `$(install_dependencies $PKG)` to `install_dependencies $PKG`

###### Does this affect the toolchain?
NO

###### Test Methodology
- Verified the fix by examining the code logic
- Confirmed that `install_dependencies` function executes commands internally rather than returning them
- Ensured the fix follows bash security best practices

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/a8d07636-a678-4a0a-8b32-5e6b4af68b79)

Comment @datadog to request changes