### PR TITLE
Harden guice tarball glob handling

### DIFF
--- a/SPECS/google-guice/create_source_tarball.sh
+++ b/SPECS/google-guice/create_source_tarball.sh
@@ -69,7 +69,7 @@ find . -name "*.jar" -delete
 find . -name "*.class" -delete
 cd ..
 
-tar czf "${OUT_FOLDER}/${name}-${version}.tar.gz" *
+tar czf "${OUT_FOLDER}/${name}-${version}.tar.gz" -- ./*
 cd ..
 rm -r tarball-tmp "${name}-${version}.orig.tar.gz"
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"657d67cf-562f-4358-8c21-c1c89fb038fe","source":"chat","resourceId":"a3f7b31f-eb80-409a-9e27-c35796986e3b","workflowId":"978b270a-b256-4113-9aca-4180f10b1906","codeChangeId":"978b270a-b256-4113-9aca-4180f10b1906","sourceType":"code_security_sast"} -->
###### Motivation

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/c08892fa3fc121f311ee1b79068ff5b1?panel_event_id=AwAAAZ8iF6XTvcDVdAAAABhBWjhpRjZYVEFBQUI4Y01kU24wZ1BBNGMAAAAkZjE5ZjIyMWMtMmQyNy00NjViLWJjZGYtOTllOGJjNTM2MmU5AABoYQ&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22YzA4ODkyZmEzZmMxMjFmMzExZWUxYjc5MDY4ZmY1YjF-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22+%22Glob+may+expand+to+names+starting+with+-+and+be+parsed+as+options%3B+use+.%2F%2A+or+--+before+the+glob%22)

Address a critical SAST finding (bash-security/prevent-option-injection-via-globs) in `SPECS/google-guice/create_source_tarball.sh`. The previous bare `*` argument could expand to filenames beginning with `-`, which may be interpreted as `tar` options.

###### Changes
- Replaced `tar czf "${OUT_FOLDER}/${name}-${version}.tar.gz" *` with `tar czf "${OUT_FOLDER}/${name}-${version}.tar.gz" -- ./*`.
- Added `--` to explicitly stop option parsing.
- Used `./*` so expanded paths are treated as file paths, not options.

###### Testing
- Ran: `bash -n SPECS/google-guice/create_source_tarball.sh`
- Inspected diff to confirm only the targeted line changed.

###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Harden the google-guice source tarball packaging script to prevent option injection through glob expansion.

###### Change Log  <!-- REQUIRED -->
- Updated `SPECS/google-guice/create_source_tarball.sh` tar invocation to use `-- ./*` instead of `*`
- Mitigated option-injection risk when unexpected filenames begin with `-`
- Kept behavior/functionality unchanged aside from argument safety hardening

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
- N/A

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
- `bash -n SPECS/google-guice/create_source_tarball.sh`
- Targeted diff review

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/a3f7b31f-eb80-409a-9e27-c35796986e3b)

Comment @datadog to request changes