### PR TITLE
Harden kdump ssh vmcore write command

### DIFF
--- a/SPECS/kexec-tools/dracut-kdump.sh
+++ b/SPECS/kexec-tools/dracut-kdump.sh
@@ -108,6 +108,7 @@ dump_ssh()
     local _opt="-i $1 -o BatchMode=yes -o StrictHostKeyChecking=yes"
     local _dir="$KDUMP_PATH/$HOST_IP-$DATEDIR"
     local _host=$2
+    local _remote_vmcore_incomplete
 
     echo "kdump: saving to $_host:$_dir"
 
@@ -123,7 +124,8 @@ dump_ssh()
         scp -q $_opt /proc/vmcore "$_host:$_dir/vmcore-incomplete" || return 1
         ssh $_opt $_host "mv $_dir/vmcore-incomplete $_dir/vmcore" || return 1
     else
-        $CORE_COLLECTOR /proc/vmcore | ssh $_opt $_host "dd bs=512 of=$_dir/vmcore-incomplete" || return 1
+        printf -v _remote_vmcore_incomplete '%q' "$_dir/vmcore-incomplete"
+        $CORE_COLLECTOR /proc/vmcore | ssh $_opt $_host 'dd bs=512 of='"${_remote_vmcore_incomplete}" || return 1
         ssh $_opt $_host "mv $_dir/vmcore-incomplete $_dir/vmcore.flat" || return 1
     fi
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"0b0d6238-6f93-40da-b5fb-073c2c6b70bc","source":"chat","resourceId":"4d1e882a-9a28-461b-b02b-7ff9cc603453","workflowId":"77877030-9612-4a73-ace8-b92fe55f6c4c","codeChangeId":"77877030-9612-4a73-ace8-b92fe55f6c4c","sourceType":"code_security_sast"} -->
###### Motivation

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/bc1b053bd3e2ac43a24f70d399b1f9bc?panel_event_id=AwAAAZ8itckOJkaS1QAAABhBWjhpdGNrT0FBQkY1ZEdaWjkteExsQW4AAAAkZjE5ZjIyYjYtMDhlOC00MjZjLWI2YzgtMTE5MTM4ZTVlZjIzAAAAMw&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22YmMxYjA1M2JkM2UyYWM0M2EyNGY3MGQzOTliMWY5YmN-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22+%22This+double-quoted+ssh+operand+%28the+last+one%29+expands+variables+and+command+substitutions+on+the+client+before+the+remote+shell+runs%3B+use+single+quotes+for+remote+text+or+escape+%24+when+expansion+must+stay+local%22)

A critical SAST finding reported that the kdump ssh remote command used a double-quoted remote operand, which allows local shell expansion before the remote shell executes. This hardens the crash dump path by making remote command construction explicit and safer.

###### Changes
- Updated `SPECS/kexec-tools/dracut-kdump.sh` in `dump_ssh`.
- Added `_remote_vmcore_incomplete` and shell-escaped the remote output path with `printf -v ... '%q'`.
- Replaced the double-quoted ssh `dd` command with a single-quoted remote command body plus explicit interpolation of the escaped path.
- Preserved existing dump flow and output file names.

###### Testing
- `bash -n SPECS/kexec-tools/dracut-kdump.sh`
- Ran automation lint step (`Lint`), which reported no auto-detected linter for this shell file.

###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
This PR addresses a critical SAST issue in the kdump ssh dump path by removing the double-quoted remote `ssh` command operand that performed local expansion before remote execution.

###### Change Log  <!-- REQUIRED -->
- Hardened `dump_ssh` remote vmcore write command construction in `SPECS/kexec-tools/dracut-kdump.sh`
- Added shell-escaping for the remote vmcore output path before invoking `ssh`
- Kept existing kdump behavior and output naming intact

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
- N/A

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
- Local syntax validation: `bash -n SPECS/kexec-tools/dracut-kdump.sh`
- Automation lint pass: no auto-detected linter for this shell file

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/4d1e882a-9a28-461b-b02b-7ff9cc603453)

Comment @datadog to request changes