### PR TITLE
Harden kdump SSH remote path quoting

### DIFF
--- a/SPECS/kexec-tools/dracut-kdump.sh
+++ b/SPECS/kexec-tools/dracut-kdump.sh
@@ -81,6 +81,11 @@ add_dump_code()
     DUMP_INSTRUCTION=$1
 }
 
+quote_for_remote_shell()
+{
+    printf "'%s'" "$(printf "%s" "$1" | sed "s/'/'\\\\''/g")"
+}
+
 dump_raw()
 {
     local _raw=$1
@@ -107,12 +112,16 @@ dump_ssh()
 {
     local _opt="-i $1 -o BatchMode=yes -o StrictHostKeyChecking=yes"
     local _dir="$KDUMP_PATH/$HOST_IP-$DATEDIR"
+    local _dir_remote=$(quote_for_remote_shell "$_dir")
+    local _vmcore_incomplete_remote=$(quote_for_remote_shell "$_dir/vmcore-incomplete")
+    local _vmcore_remote=$(quote_for_remote_shell "$_dir/vmcore")
+    local _vmcore_flat_remote=$(quote_for_remote_shell "$_dir/vmcore.flat")
     local _host=$2
 
     echo "kdump: saving to $_host:$_dir"
 
     cat /var/lib/random-seed > /dev/urandom
-    ssh -q $_opt $_host mkdir -p $_dir || return 1
+    ssh -q $_opt $_host 'mkdir -p '"$_dir_remote" || return 1
 
     save_vmcore_dmesg_ssh ${DMESG_COLLECTOR} ${_dir} "${_opt}" $_host
     save_opalcore_ssh ${_dir} "${_opt}" $_host
@@ -121,10 +130,10 @@ dump_ssh()
 
     if [ "${CORE_COLLECTOR%%[[:blank:]]*}" = "scp" ]; then
         scp -q $_opt /proc/vmcore "$_host:$_dir/vmcore-incomplete" || return 1
-        ssh $_opt $_host "mv $_dir/vmcore-incomplete $_dir/vmcore" || return 1
+        ssh $_opt $_host 'mv '"$_vmcore_incomplete_remote"' '"$_vmcore_remote" || return 1
     else
-        $CORE_COLLECTOR /proc/vmcore | ssh $_opt $_host "dd bs=512 of=$_dir/vmcore-incomplete" || return 1
-        ssh $_opt $_host "mv $_dir/vmcore-incomplete $_dir/vmcore.flat" || return 1
+        $CORE_COLLECTOR /proc/vmcore | ssh $_opt $_host 'dd bs=512 of='"$_vmcore_incomplete_remote" || return 1
+        ssh $_opt $_host 'mv '"$_vmcore_incomplete_remote"' '"$_vmcore_flat_remote" || return 1
     fi
 
     echo "kdump: saving vmcore complete"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"ef8dd965-263f-4d4a-a178-43469583440a","source":"chat","resourceId":"b066ceee-0854-4044-a077-550f29d7bdfe","workflowId":"4b3a55e3-5192-4d62-bcf3-9c6f9c1beda7","codeChangeId":"4b3a55e3-5192-4d62-bcf3-9c6f9c1beda7","sourceType":"code_security_sast"} -->
###### Merge Checklist  <!-- REQUIRED -->

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/d879d4f256bb7a78439497e6b8129387?panel_event_id=AwAAAZ8ivTaQ71GdFAAAABhBWjhpdlRhUUFBQ2t5dXZIOW5CN0dRV3kAAAAkZjE5ZjIyYmQtNDIxNC00YzZkLWE1ODAtOWFiM2JmOWE3MDgzAAACmQ&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22ZDg3OWQ0ZjI1NmJiN2E3ODQzOTQ5N2U2YjgxMjkzODd-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22+%22This+double-quoted+ssh+operand+%28the+last+one%29+expands+variables+and+command+substitutions+on+the+client+before+the+remote+shell+runs%3B+use+single+quotes+for+remote+text+or+escape+%24+when+expansion+must+stay+local%22)

**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
This change hardens remote `ssh` command construction in kdump vmcore upload flow to address a critical SAST finding (`bash-security/local-expansion-in-remote-command`).

The previous implementation built remote commands with double-quoted operands containing local variable expansion, which can lead to unsafe shell interpretation when values include shell metacharacters. The update now quotes remote paths explicitly before embedding them in `ssh` command text.

###### Change Log  <!-- REQUIRED -->
- Added `quote_for_remote_shell()` in `SPECS/kexec-tools/dracut-kdump.sh` to safely single-quote values for remote shell execution.
- Updated `dump_ssh()` to precompute quoted remote path variants for vmcore destinations.
- Replaced vulnerable remote command strings with single-quoted command text plus safely quoted path operands for `mkdir`, `mv`, and `dd` over `ssh`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
- N/A

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
- `bash -n SPECS/kexec-tools/dracut-kdump.sh`
- Manual quoting sanity check for the new `quote_for_remote_shell()` escaping behavior

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/b066ceee-0854-4044-a077-550f29d7bdfe)

Comment @datadog to request changes