### PR TITLE
Harden kdump ssh vmcore-dmesg command

### DIFF
--- a/SPECS/kexec-tools/dracut-kdump.sh
+++ b/SPECS/kexec-tools/dracut-kdump.sh
@@ -162,13 +162,19 @@ save_vmcore_dmesg_ssh() {
     local _path=$2
     local _opts="$3"
     local _location=$4
+    local _dmesg_incomplete_path="${_path}/vmcore-dmesg-incomplete.txt"
+    local _dmesg_path="${_path}/vmcore-dmesg.txt"
+    local _dmesg_incomplete_path_escaped=$(printf "%s" "$_dmesg_incomplete_path" | sed "s/'/'\\\\''/g")
+    local _dmesg_path_escaped=$(printf "%s" "$_dmesg_path" | sed "s/'/'\\\\''/g")
+    local _remote_dd_cmd=$(printf "dd of='%s'" "$_dmesg_incomplete_path_escaped")
+    local _remote_mv_cmd=$(printf "mv '%s' '%s'" "$_dmesg_incomplete_path_escaped" "$_dmesg_path_escaped")
 
     echo "kdump: saving vmcore-dmesg.txt"
-    $_dmesg_collector /proc/vmcore | ssh $_opts $_location "dd of=$_path/vmcore-dmesg-incomplete.txt"
+    $_dmesg_collector /proc/vmcore | ssh $_opts "$_location" "$_remote_dd_cmd"
     _exitcode=$?
 
     if [ $_exitcode -eq 0 ]; then
-        ssh -q $_opts $_location mv $_path/vmcore-dmesg-incomplete.txt $_path/vmcore-dmesg.txt
+        ssh -q $_opts "$_location" "$_remote_mv_cmd"
         echo "kdump: saving vmcore-dmesg.txt complete"
     else
         echo "kdump: saving vmcore-dmesg.txt failed"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"d7409ff6-2954-4652-bf40-46b867d983bc","source":"chat","resourceId":"d7a0a783-4ab5-45ca-8140-e31f4a77a8af","workflowId":"71b0d55d-ba08-4723-b53e-a0187379a7d1","codeChangeId":"71b0d55d-ba08-4723-b53e-a0187379a7d1","sourceType":"code_security_sast"} -->
###### Motivation

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/938fe8a8057fea7ad9ef974165a711b8?panel_event_id=AwAAAZ8ivTYgA2zrTwAAABhBWjhpdlRZZ0FBQmgtMm54SnUyc0cyUHUAAAAkZjE5ZjIyYmQtZWQ1ZS00MjA0LWJmYjUtMDY0NjZlNmUxZTJjAAAI2Q&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22OTM4ZmU4YTgwNTdmZWE3YWQ5ZWY5NzQxNjVhNzExYjh-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22+%22This+double-quoted+ssh+operand+%28the+last+one%29+expands+variables+and+command+substitutions+on+the+client+before+the+remote+shell+runs%3B+use+single+quotes+for+remote+text+or+escape+%24+when+expansion+must+stay+local%22)

- Fix a critical SAST finding (bash-security/local-expansion-in-remote-command) in `SPECS/kexec-tools/dracut-kdump.sh` where an SSH remote command was built from a path derived from kdump configuration without escaping.
- Prevent remote shell interpretation issues when path values contain special characters.

###### Changes
- Added explicit `vmcore-dmesg` remote path variables in `save_vmcore_dmesg_ssh`.
- Escaped single quotes in remote path values before composing SSH command text.
- Switched the `dd` and `mv` SSH invocations to use prebuilt, escaped remote command strings.

###### Testing
- Ran `bash -n SPECS/kexec-tools/dracut-kdump.sh`.

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

This PR hardens SSH-based vmcore-dmesg transfer in kexec-tools by escaping remote file paths before command construction, addressing a critical SAST finding for client-side expansion in SSH remote command text.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Updated `SPECS/kexec-tools/dracut-kdump.sh` in `save_vmcore_dmesg_ssh` to compute explicit remote dmesg paths.
- Escaped single quotes in computed remote paths using `sed` before embedding in SSH command text.
- Replaced direct inline SSH command strings with escaped command variables for `dd` and `mv` operations.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- None

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Local static validation: `bash -n SPECS/kexec-tools/dracut-kdump.sh`

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/d7a0a783-4ab5-45ca-8140-e31f4a77a8af)

Comment @datadog to request changes