### PR TITLE
Quote tmpdir expansion in cleanup script

### DIFF
--- a/SPECS/moby-compose/generate_source_tarball.sh
+++ b/SPECS/moby-compose/generate_source_tarball.sh
@@ -83,7 +83,7 @@ echo "-- create temp folder"
 tmpdir=$(mktemp -d)
 function cleanup {
     echo "+++ cleanup -> remove $tmpdir"
-    rm -rf $tmpdir
+    rm -rf "$tmpdir"
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"ba1c8e40-16a8-48bd-9369-8249c45eab1d","source":"chat","resourceId":"61c10180-0daa-4dd8-8b7c-de5b1f6eff6e","workflowId":"4eee3e8c-d87f-42bd-aab6-db5f869409c5","codeChangeId":"4eee3e8c-d87f-42bd-aab6-db5f869409c5","sourceType":"code_security_sast"} -->
###### Motivation

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/2fa5f29d976b2d44105665afdc646d85?panel_event_id=AwAAAZ8i52_OaDdRlAAAABhBWjhpNTJfT0FBQmlSaTlWMndHN3RELWEAAAAkZjE5ZjIyZTctOWZlZi00MzkxLTljMTgtZjMxZDQ0NDQxZDg4AAAIzw&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22MmZhNWYyOWQ5NzZiMmQ0NDEwNTY2NWFmZGM2NDZkODV-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22+%22Double+quote+variable+expansions+to+prevent+word+splitting+and+glob+expansion%22)

Prevent unsafe shell expansion in cleanup logic. Unquoted use of `$tmpdir` in `rm -rf` can be split or glob-expanded if the temp path contains spaces or wildcard characters (for example via environment-influenced temp directories), which can broaden deletion scope unexpectedly.

###### Changes
- Quoted the temporary directory variable in cleanup: `rm -rf "$tmpdir"`.
- Kept the fix narrowly scoped to the reported high-severity SAST finding in `SPECS/moby-compose/generate_source_tarball.sh`.
- Preserved existing script behavior while hardening path handling.

###### Testing
- Ran: `bash -n SPECS/moby-compose/generate_source_tarball.sh`
- Confirmed no syntax errors.

###### Merge Checklist
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary
This PR fixes a high-severity shell-safety issue by quoting the temporary directory variable used in cleanup, preventing word splitting and glob expansion during `rm -rf`.

###### Change Log
- Updated `SPECS/moby-compose/generate_source_tarball.sh` cleanup to use `rm -rf "$tmpdir"`.
- Addressed SAST rule `bash-security/double-quote-variable-expansions` (Finding ID: MmZhNWYyOWQ5NzZiMmQ0NDEwNTY2NWFmZGM2NDZkODV-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY=).
- No functional changes expected besides safer handling of path expansion.

###### Does this affect the toolchain?
NO

###### Associated issues
- N/A

###### Links to CVEs
- N/A

###### Test Methodology
- Local validation: `bash -n SPECS/moby-compose/generate_source_tarball.sh`

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/61c10180-0daa-4dd8-8b7c-de5b1f6eff6e)

Comment @datadog to request changes