### PR TITLE
Harden output update script arg quoting

### DIFF
--- a/toolkit/scripts/update-target-if-output-changed.sh
+++ b/toolkit/scripts/update-target-if-output-changed.sh
@@ -20,17 +20,17 @@ usage() {
 
 [[ -z "$flagFile" || -z "$oldOutputFile" || -z "$newOutputFile" ]] && usage
 
-if [[ ! -f $flagFile ]] || [[ ! -f $oldOutputFile ]]; then
+if [[ ! -f "$flagFile" ]] || [[ ! -f "$oldOutputFile" ]]; then
 	echo "Creating $flagFile"
-	touch $flagFile
+	touch "$flagFile"
 	exit 0
 fi
 
-cmp --silent $oldOutputFile $newOutputFile
+cmp --silent "$oldOutputFile" "$newOutputFile"
 comparisonResult=$?
 
 if [[ $comparisonResult != 0 ]]; then
 	echo "Creating $flagFile"
-	touch $flagFile
+	touch "$flagFile"
 fi
-rm $oldOutputFile
+rm "$oldOutputFile"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"372da575-839f-4ddc-87ec-9c7fc2db05f4","source":"chat","resourceId":"03e5048e-7df8-4af0-bb88-d7b9c1850ee0","workflowId":"443f6121-1058-4b4c-b2ab-f793deb5dc8c","codeChangeId":"443f6121-1058-4b4c-b2ab-f793deb5dc8c","sourceType":"code_security_sast"} -->
###### Motivation

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/60e1176d08e1178f503692b1714b9ee2?panel_event_id=AwAAAZ8i6gqVtYnsPQAAABhBWjhpNmdxVkFBQ2hFLU1EVTAzOTRMbnQAAAAkZjE5ZjIyZWEtMmIzMi00NzdhLWFmYmEtMDc1MTRkOGUzMWViAAAANQ&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22NjBlMTE3NmQwOGUxMTc4ZjUwMzY5MmIxNzE0YjllZTJ-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22+%22Double+quote+variable+expansions+to+prevent+word+splitting+and+glob+expansion%22)

This change addresses a high-severity SAST finding (`bash-security/double-quote-variable-expansions`) in `toolkit/scripts/update-target-if-output-changed.sh`. Unquoted file-path expansions could trigger word splitting or glob expansion, which can cause incorrect file comparison, flag creation, or file removal behavior when paths include spaces or wildcard characters.

###### Changes
- Added defensive double-quoting for file-path variable expansions used by shell commands in `toolkit/scripts/update-target-if-output-changed.sh`.
- Updated `touch`, `cmp`, and `rm` invocations so each path is passed as a single argument.
- Kept script behavior unchanged apart from safer argument handling.

###### Testing
- `bash -n toolkit/scripts/update-target-if-output-changed.sh`
- Attempted `shellcheck toolkit/scripts/update-target-if-output-changed.sh` (not available in this sandbox).

###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
What does the PR accomplish, why was it needed?

This PR fixes a high-severity shell-safety issue by quoting variable expansions in `toolkit/scripts/update-target-if-output-changed.sh` so path arguments are handled safely and consistently.

###### Change Log  <!-- REQUIRED -->
- Quoted `$flagFile` and `$oldOutputFile` in `[[ -f ... ]]` checks.
- Quoted `$oldOutputFile` and `$newOutputFile` for `cmp --silent`.
- Quoted `$flagFile` and `$oldOutputFile` for `touch` and `rm` operations.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Associated issues  <!-- optional -->
- N/A

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
- Local validation: `bash -n toolkit/scripts/update-target-if-output-changed.sh`
- Local validation: attempted `shellcheck` (not installed in this environment)

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/03e5048e-7df8-4af0-bb88-d7b9c1850ee0)

Comment @datadog to request changes