### PR TITLE
Quote source tarball args in flux script

### DIFF
--- a/SPECS/flux/generate_source_tarball.sh
+++ b/SPECS/flux/generate_source_tarball.sh
@@ -77,7 +77,7 @@ trap cleanup EXIT
 
 TARBALL_FOLDER="$tmpdir/tarballFolder"
 mkdir -p $TARBALL_FOLDER
-cp $SRC_TARBALL $tmpdir
+cp "$SRC_TARBALL" "$tmpdir"
 
 pushd $tmpdir > /dev/null
 
@@ -86,7 +86,7 @@ NAME_VER="$PKG_NAME-$PKG_VERSION"
 VENDOR_TARBALL="$OUT_FOLDER/$NAME_VER-cargo.tar.gz"
 
 echo "Unpacking source tarball..."
-tar -xf $SRC_TARBALL
+tar -xf "$SRC_TARBALL"
 
 echo "Vendor cargo ..."
 cd $NAME_VER/libflux


### PR DESCRIPTION
<!-- dd-meta {"pullId":"eddf2024-8fa9-41da-8d02-5b769aad131b","source":"chat","resourceId":"a2c8fb15-1414-4427-b7a5-576249347b40","workflowId":"882ddb05-397e-4381-883f-79813a137b88","codeChangeId":"882ddb05-397e-4381-883f-79813a137b88","sourceType":"code_security_sast"} -->
###### Merge Checklist  <!-- REQUIRED -->

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/eeb9ccae1ca23b1cc0aa7909aae87a83?panel_event_id=AwAAAZ8i8BCfznUVygAAABhBWjhpOEJDZkFBQ0VYM3ZxcTd2bTVGOV8AAAAkZjE5ZjIyZjItNGEzZS00ZjUzLThjMTUtMGE3NzFkYzJmODcyAAAElA&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22ZWViOWNjYWUxY2EyM2IxY2MwYWE3OTA5YWFlODdhODN-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22+%22Double+quote+variable+expansions+to+prevent+word+splitting+and+glob+expansion%22)

**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Fixes a high-severity SAST finding in the Flux source tarball generation script by preventing shell word splitting and glob expansion for the user-supplied source tarball path.

###### Change Log  <!-- REQUIRED -->
- Quoted `SRC_TARBALL` and `tmpdir` expansions in the `cp` invocation in `SPECS/flux/generate_source_tarball.sh`.
- Quoted `SRC_TARBALL` in the `tar -xf` invocation so tarball paths with spaces/globs are treated as a single argument.
- Kept the change scoped to the vulnerable command arguments to minimize behavior impact while removing unsafe expansion.

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
- N/A

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
- `bash -n SPECS/flux/generate_source_tarball.sh`
- `shellcheck` is not available in this sandbox, so no additional shell linting was run.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/a2c8fb15-1414-4427-b7a5-576249347b40)

Comment @datadog to request changes