### PR TITLE
Quote src tarball args in flux script

### DIFF
--- a/SPECS/flux/generate_source_tarball.sh
+++ b/SPECS/flux/generate_source_tarball.sh
@@ -76,17 +76,17 @@ function cleanup {
 trap cleanup EXIT
 
 TARBALL_FOLDER="$tmpdir/tarballFolder"
-mkdir -p $TARBALL_FOLDER
-cp $SRC_TARBALL $tmpdir
+mkdir -p "$TARBALL_FOLDER"
+cp -- "$SRC_TARBALL" "$tmpdir"
 
-pushd $tmpdir > /dev/null
+pushd "$tmpdir" > /dev/null
 
 PKG_NAME="flux"
 NAME_VER="$PKG_NAME-$PKG_VERSION"
 VENDOR_TARBALL="$OUT_FOLDER/$NAME_VER-cargo.tar.gz"
 
 echo "Unpacking source tarball..."
-tar -xf $SRC_TARBALL
+tar -xf "$SRC_TARBALL"
 
 echo "Vendor cargo ..."
 cd $NAME_VER/libflux


### PR DESCRIPTION
<!-- dd-meta {"pullId":"ebbd9ed6-3200-491e-ba08-2734c9681205","source":"chat","resourceId":"7f204f37-92ef-4e58-b689-adb0e37f41ea","workflowId":"eb9f6872-e10c-4687-aa94-be9590013848","codeChangeId":"eb9f6872-e10c-4687-aa94-be9590013848","sourceType":"code_security_sast"} -->
###### Merge Checklist  <!-- REQUIRED -->

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/eeb9ccae1ca23b1cc0aa7909aae87a83?panel_event_id=AwAAAZ8i8BCfznUVygAAABhBWjhpOEJDZkFBQ0VYM3ZxcTd2bTVGOV8AAAAkZjE5ZjIyZjItNGEzZS00ZjUzLThjMTUtMGE3NzFkYzJmODcyAAAElA&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22ZWViOWNjYWUxY2EyM2IxY2MwYWE3OTA5YWFlODdhODN-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22+%22Double+quote+variable+expansions+to+prevent+word+splitting+and+glob+expansion%22)

**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add @microsoft/cbl-mariner-multi-package-reviewers team as reviewer (example: golang has 2 versions 1.18, 1.21+)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
This change fixes a high-severity shell scripting risk in the flux source tarball generator. The `--srcTarball` argument is user-provided, and unquoted expansion could trigger word splitting or glob expansion, causing unintended file resolution and unsafe command behavior.

###### Change Log  <!-- REQUIRED -->
- Quoted `TARBALL_FOLDER` when creating the directory to avoid path splitting.
- Replaced `cp $SRC_TARBALL $tmpdir` with `cp -- "$SRC_TARBALL" "$tmpdir"` to safely handle user-provided tarball paths.
- Quoted related path usages (`pushd "$tmpdir"` and `tar -xf "$SRC_TARBALL"`) to keep argument handling consistent and safe.

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
- None

###### Links to CVEs  <!-- optional -->
- None

###### Test Methodology
- `bash -n SPECS/flux/generate_source_tarball.sh`
- Diff review of `SPECS/flux/generate_source_tarball.sh` to confirm only targeted quoting/argument-safety updates were introduced.
- `shellcheck` is not available in this sandbox environment.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/7f204f37-92ef-4e58-b689-adb0e37f41ea)

Comment @datadog to request changes