### PR TITLE
Quote path expansions in moby-compose script

### DIFF
--- a/SPECS/moby-compose/generate_source_tarball.sh
+++ b/SPECS/moby-compose/generate_source_tarball.sh
@@ -83,22 +83,22 @@ echo "-- create temp folder"
 tmpdir=$(mktemp -d)
 function cleanup {
     echo "+++ cleanup -> remove $tmpdir"
-    rm -rf $tmpdir
+    rm -rf "$tmpdir"
 }
 trap cleanup EXIT
 
 TARBALL_FOLDER="$tmpdir/tarballFolder"
-mkdir -p $TARBALL_FOLDER
-cp $SRC_TARBALL $tmpdir
+mkdir -p "$TARBALL_FOLDER"
+cp "$SRC_TARBALL" "$tmpdir"
 
-pushd $tmpdir > /dev/null
+pushd "$tmpdir" > /dev/null
 
 PKG_NAME="moby-compose"
 NAME_VER="$PKG_NAME-$PKG_VERSION"
 VENDOR_TARBALL="$OUT_FOLDER/$NAME_VER-govendor-v$VENDOR_VERSION.tar.gz"
 
 echo "Unpacking source tarball..."
-tar -xf $SRC_TARBALL
+tar -xf "$SRC_TARBALL"
 
 echo "Vendor go modules..."
 cd compose-"$PKG_VERSION"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"ea166bbe-e630-4e5b-9b6b-9113883773e5","source":"chat","resourceId":"445534ad-70cd-4932-925a-4da3d1871ebd","workflowId":"ed05c64c-9a4b-46ec-aaf4-f5feceda825b","codeChangeId":"ed05c64c-9a4b-46ec-aaf4-f5feceda825b","sourceType":"code_security_sast"} -->
###### Motivation

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/fe3d9ccddedbde4313e79425bf578afb?panel_event_id=AwAAAZ8i8MwtKH5TowAAABhBWjhpOE13dEFBQUU4MTVRMUxqR3RVX0sAAAAkZjE5ZjIyZjItNGEzZS00ZjUzLThjMTUtMGE3NzFkYzJmODcyAAAEgA&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22ZmUzZDljY2RkZWRiZGU0MzEzZTc5NDI1YmY1NzhhZmJ-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22+%22Double+quote+variable+expansions+to+prevent+word+splitting+and+glob+expansion%22)

SAST flagged unquoted shell variable expansions in the tarball generation script. Unquoted path expansions can trigger word splitting and glob expansion when values contain spaces or wildcard characters (for example from environment-controlled temp paths or user-supplied source tarball paths), leading to unintended file operations.

###### Changes
- Quoted `tmpdir` in cleanup removal to prevent splitting/globbing.
- Quoted `TARBALL_FOLDER` when creating the tarball workspace directory.
- Quoted `SRC_TARBALL` and `tmpdir` in copy/extract steps and quoted `tmpdir` in `pushd`.
- Kept behavior unchanged while hardening argument handling in command invocations.

###### Testing
- `bash -n SPECS/moby-compose/generate_source_tarball.sh`
- Attempted `shellcheck SPECS/moby-compose/generate_source_tarball.sh` (not available in this sandbox).

###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add @microsoft/cbl-mariner-multi-package-reviewers team as reviewer (Eg. golang has 2 versions 1.18, 1.21+)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
This PR hardens `SPECS/moby-compose/generate_source_tarball.sh` by quoting variable expansions in filesystem and archive commands to prevent unintended word splitting and glob expansion.

###### Change Log  <!-- REQUIRED -->
- Quote `rm -rf "$tmpdir"` in cleanup.
- Quote `mkdir`, `cp`, and `pushd` path arguments used for tarball staging.
- Quote `tar -xf "$SRC_TARBALL"` extraction input.

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
- None

###### Links to CVEs  <!-- optional -->
- None

###### Test Methodology
- Local syntax check: `bash -n SPECS/moby-compose/generate_source_tarball.sh`
- Environment note: `shellcheck` is unavailable in this sandbox

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/445534ad-70cd-4932-925a-4da3d1871ebd)

Comment @datadog to request changes