### PR TITLE
Quote unsafe expansions in moby-compose script

### DIFF
--- a/SPECS/moby-compose/generate_source_tarball.sh
+++ b/SPECS/moby-compose/generate_source_tarball.sh
@@ -83,22 +83,22 @@ echo "-- create temp folder"
 tmpdir=$(mktemp -d)
 function cleanup {
     echo "+++ cleanup -> remove $tmpdir"
-    rm -rf $tmpdir
+    rm -rf "$tmpdir"
 }
 trap cleanup EXIT
 
 TARBALL_FOLDER="$tmpdir/tarballFolder"
-mkdir -p $TARBALL_FOLDER
-cp $SRC_TARBALL $tmpdir
+mkdir -p "$TARBALL_FOLDER"
+cp "$SRC_TARBALL" "$tmpdir"
 
-pushd $tmpdir > /dev/null
+pushd "$tmpdir" > /dev/null
 
 PKG_NAME="moby-compose"
 NAME_VER="$PKG_NAME-$PKG_VERSION"
 VENDOR_TARBALL="$OUT_FOLDER/$NAME_VER-govendor-v$VENDOR_VERSION.tar.gz"
 
 echo "Unpacking source tarball..."
-tar -xf $SRC_TARBALL
+tar -xf "$SRC_TARBALL"
 
 echo "Vendor go modules..."
 cd compose-"$PKG_VERSION"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"8dd20132-1d95-4521-9a99-6f67a3029e2c","source":"chat","resourceId":"be0f42a8-6311-48a3-ba21-ed5b609c31f0","workflowId":"33b10e9b-6e88-4e4d-b939-fe143f7c23cb","codeChangeId":"33b10e9b-6e88-4e4d-b939-fe143f7c23cb","sourceType":"code_security_sast"} -->
###### Merge Checklist  <!-- REQUIRED -->

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/fe3d9ccddedbde4313e79425bf578afb?panel_event_id=AwAAAZ8i8MwtKH5TowAAABhBWjhpOE13dEFBQUU4MTVRMUxqR3RVX0sAAAAkZjE5ZjIyZjItNGEzZS00ZjUzLThjMTUtMGE3NzFkYzJmODcyAAAEgA&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22ZmUzZDljY2RkZWRiZGU0MzEzZTc5NDI1YmY1NzhhZmJ-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22+%22Double+quote+variable+expansions+to+prevent+word+splitting+and+glob+expansion%22)

**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
This change fixes a high-severity SAST issue in `SPECS/moby-compose/generate_source_tarball.sh` where unquoted variable expansions in command arguments could trigger word splitting or glob expansion. Quoting these expansions prevents malformed paths or wildcard characters from changing command behavior and improves packaging-script safety.

###### Change Log  <!-- REQUIRED -->
- Quote variable expansions used in command arguments for `rm`, `mkdir`, `cp`, `pushd`, and `tar` in `generate_source_tarball.sh`.
- Keep script behavior unchanged while hardening path handling against shell word splitting/globbing.
- Resolve finding `bash-security/double-quote-variable-expansions` for the reported location.

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
- N/A

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
- `bash -n SPECS/moby-compose/generate_source_tarball.sh`
- `shellcheck SPECS/moby-compose/generate_source_tarball.sh` *(not available in this sandbox: `shellcheck not installed`)*

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/be0f42a8-6311-48a3-ba21-ed5b609c31f0)

Comment @datadog to request changes