### PR TITLE
Quote toolchain spec path expansions

### DIFF
--- a/toolkit/scripts/toolchain/list_toolchain_specs.sh
+++ b/toolkit/scripts/toolchain/list_toolchain_specs.sh
@@ -14,7 +14,7 @@ OUTPUT_FILE=$2
 # In both cases, the first entry is the actual spec name to extract.
 # The below sed command will extract every spec name that follows the above pattern and place it in $OUTPUT_FILE.
 # `sort -u` is for eliminating duplicates- we don't actually care about the order
-sed -nE 's/^\s*build_rpm_in_chroot_no_install\s+([A-Za-z0-9_-]+).*$/\1/pgm' $TOOLCHAIN_BUILD_FILE | sort -u > $OUTPUT_FILE
+sed -nE 's/^\s*build_rpm_in_chroot_no_install\s+([A-Za-z0-9_-]+).*$/\1/pgm' "$TOOLCHAIN_BUILD_FILE" | sort -u > "$OUTPUT_FILE"
 
 # Special case to add msopenjdk-11 RPM which is downloaded instead of built
-echo "msopenjdk-11" >> $OUTPUT_FILE
+echo "msopenjdk-11" >> "$OUTPUT_FILE"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"aba4dc15-1e6e-42ea-8d2c-ad947fe5e4c1","source":"chat","resourceId":"0dbbbc75-5efe-45e0-a833-3fd226270c9f","workflowId":"14676241-388a-4a71-a603-fadc1e432910","codeChangeId":"14676241-388a-4a71-a603-fadc1e432910","sourceType":"code_security_sast"} -->
###### Motivation

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/79692fcb75bdf319db1e604cf65ced12?panel_event_id=AwAAAZ8i8HpK4nPe0wAAABhBWjhpOEhwS0FBQkEtS3lBNTRJcncxeGQAAAAkZjE5ZjIyZjItNGEzZS00ZjUzLThjMTUtMGE3NzFkYzJmODcyAAAEiw&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22Nzk2OTJmY2I3NWJkZjMxOWRiMWU2MDRjZjY1Y2VkMTJ-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22+%22Double+quote+variable+expansions+to+prevent+word+splitting+and+glob+expansion%22)

The SAST finding `bash-security/double-quote-variable-expansions` identified unquoted path arguments in `list_toolchain_specs.sh`. Quoting these expansions prevents word splitting and glob expansion, which could otherwise cause ambiguous redirects or unintended path resolution when build paths contain spaces or wildcard characters.

###### Changes
- Quoted `"$TOOLCHAIN_BUILD_FILE"` in the `sed` invocation that parses toolchain specs.
- Quoted `"$OUTPUT_FILE"` for both the initial write (`>`) and append (`>>`) redirections.
- Kept script behavior and output format unchanged.

###### Testing
- `bash -n toolkit/scripts/toolchain/list_toolchain_specs.sh`
- Executed `list_toolchain_specs.sh` with input/output filenames containing spaces and verified expected output entries (`bar-spec-name`, `foo-spec-name`, `msopenjdk-11`).

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
This change remediates a high-severity shell quoting issue in toolchain spec list generation by safely quoting script path arguments, reducing risk from word splitting/glob expansion without changing build logic.

###### Change Log  <!-- REQUIRED -->
- Quote positional file path expansions in `toolkit/scripts/toolchain/list_toolchain_specs.sh`.
- Preserve existing `sed` extraction and duplicate-elimination behavior.
- Keep `msopenjdk-11` append behavior unchanged while making redirection safe.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Associated issues  <!-- optional -->
- N/A

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
- Local script validation via `bash -n`.
- Local functional run with paths containing spaces to verify safe quoting behavior and expected output.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/0dbbbc75-5efe-45e0-a833-3fd226270c9f)

Comment @datadog to request changes