### PR TITLE
Quote vars in toolchain spec listing script

### DIFF
--- a/toolkit/scripts/toolchain/list_toolchain_specs.sh
+++ b/toolkit/scripts/toolchain/list_toolchain_specs.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-TOOLCHAIN_BUILD_FILE=$1
-OUTPUT_FILE=$2
+TOOLCHAIN_BUILD_FILE="$1"
+OUTPUT_FILE="$2"
 
 # Extract the specs built from toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
 # Each spec that is built will be on its own line in the following formats:
@@ -14,7 +14,7 @@ OUTPUT_FILE=$2
 # In both cases, the first entry is the actual spec name to extract.
 # The below sed command will extract every spec name that follows the above pattern and place it in $OUTPUT_FILE.
 # `sort -u` is for eliminating duplicates- we don't actually care about the order
-sed -nE 's/^\s*build_rpm_in_chroot_no_install\s+([A-Za-z0-9_-]+).*$/\1/pgm' $TOOLCHAIN_BUILD_FILE | sort -u > $OUTPUT_FILE
+sed -nE 's/^\s*build_rpm_in_chroot_no_install\s+([A-Za-z0-9_-]+).*$/\1/pgm' "$TOOLCHAIN_BUILD_FILE" | sort -u > "$OUTPUT_FILE"
 
 # Special case to add msopenjdk-11 RPM which is downloaded instead of built
-echo "msopenjdk-11" >> $OUTPUT_FILE
+echo "msopenjdk-11" >> "$OUTPUT_FILE"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"e38b4f5d-d987-4c78-89a6-1ae6d1a4f271","source":"chat","resourceId":"73bbe33e-1b3a-456d-ac4c-b5b09ddaf2f8","workflowId":"f209e450-b9d1-4059-a265-7aca88ed016b","codeChangeId":"f209e450-b9d1-4059-a265-7aca88ed016b","sourceType":"code_security_sast"} -->
###### Motivation

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/79692fcb75bdf319db1e604cf65ced12?panel_event_id=AwAAAZ8i8HpK4nPe0wAAABhBWjhpOEhwS0FBQkEtS3lBNTRJcncxeGQAAAAkZjE5ZjIyZjItNGEzZS00ZjUzLThjMTUtMGE3NzFkYzJmODcyAAAEiw&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22Nzk2OTJmY2I3NWJkZjMxOWRiMWU2MDRjZjY1Y2VkMTJ-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22+%22Double+quote+variable+expansions+to+prevent+word+splitting+and+glob+expansion%22)

The SAST finding `bash-security/double-quote-variable-expansions` flagged unquoted file-path expansions in `toolkit/scripts/toolchain/list_toolchain_specs.sh`. Unquoted path arguments can be split or glob-expanded by the shell, which can lead to incorrect file reads/writes when paths contain whitespace or wildcard characters.

###### Changes
- Quote positional argument assignments for `TOOLCHAIN_BUILD_FILE` and `OUTPUT_FILE`.
- Quote `TOOLCHAIN_BUILD_FILE` when passing it to `sed`.
- Quote `OUTPUT_FILE` for both overwrite (`>`) and append (`>>`) redirections.

###### Testing
- `bash -n toolkit/scripts/toolchain/list_toolchain_specs.sh`
- Ran the script with temporary sample input and validated output using `diff -u` against expected content.

###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
This change hardens `toolkit/scripts/toolchain/list_toolchain_specs.sh` by quoting path variable expansions so shell word splitting and glob expansion cannot alter `sed` input or output redirection targets.

###### Change Log  <!-- REQUIRED -->
- Quoted positional argument variable assignments in `list_toolchain_specs.sh`.
- Quoted `TOOLCHAIN_BUILD_FILE` in the `sed` invocation.
- Quoted `OUTPUT_FILE` redirections in both write and append operations.

###### Does this affect the toolchain?  <!-- REQUIRED -->
YES

###### Associated issues  <!-- optional -->
- None

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
- Local validation
- `bash -n toolkit/scripts/toolchain/list_toolchain_specs.sh`
- Temporary sample input/output verification with `diff -u`

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/73bbe33e-1b3a-456d-ac4c-b5b09ddaf2f8)

Comment @datadog to request changes