### PR TITLE
Harden path handling in update-target script

### DIFF
--- a/toolkit/scripts/update-target-if-output-changed.sh
+++ b/toolkit/scripts/update-target-if-output-changed.sh
@@ -20,17 +20,17 @@ usage() {
 
 [[ -z "$flagFile" || -z "$oldOutputFile" || -z "$newOutputFile" ]] && usage
 
-if [[ ! -f $flagFile ]] || [[ ! -f $oldOutputFile ]]; then
+if [[ ! -f "$flagFile" ]] || [[ ! -f "$oldOutputFile" ]]; then
 	echo "Creating $flagFile"
-	touch $flagFile
+	touch -- "$flagFile"
 	exit 0
 fi
 
-cmp --silent $oldOutputFile $newOutputFile
+cmp --silent -- "$oldOutputFile" "$newOutputFile"
 comparisonResult=$?
 
 if [[ $comparisonResult != 0 ]]; then
 	echo "Creating $flagFile"
-	touch $flagFile
+	touch -- "$flagFile"
 fi
-rm $oldOutputFile
+rm -- "$oldOutputFile"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"3d0aa888-68bc-4a93-b244-2cfaf9195668","source":"chat","resourceId":"0618d181-926b-4f3d-a7f4-25b58bca7f34","workflowId":"3a8d4c1d-f8ce-4f39-b9b7-eea408457d5b","codeChangeId":"3a8d4c1d-f8ce-4f39-b9b7-eea408457d5b","sourceType":"code_security_sast"} -->
###### Motivation

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/60e1176d08e1178f503692b1714b9ee2?panel_event_id=AwAAAZ8i6gqVtYnsPQAAABhBWjhpNmdxVkFBQ2hFLU1EVTAzOTRMbnQAAAAkZjE5ZjIyZWEtMmIzMi00NzdhLWFmYmEtMDc1MTRkOGUzMWViAAAANQ&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22NjBlMTE3NmQwOGUxMTc4ZjUwMzY5MmIxNzE0YjllZTJ-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22+%22Double+quote+variable+expansions+to+prevent+word+splitting+and+glob+expansion%22)

This change addresses a high-severity SAST finding in toolkit/scripts/update-target-if-output-changed.sh where unquoted variable expansions could trigger word splitting or glob expansion when file paths contain whitespace or pattern characters.

###### Changes
- Quoted file path variable expansions used by file checks and command arguments in toolkit/scripts/update-target-if-output-changed.sh.
- Added `--` to `touch`, `cmp`, and `rm` calls so path-like values are always treated as operands.
- Kept script behavior unchanged: create flag when needed, compare outputs, touch flag on change, and remove old output.

###### Testing
- Ran `bash -n toolkit/scripts/update-target-if-output-changed.sh`.
- Ran an end-to-end shell validation using temporary files with spaces and glob characters in names to verify:
  - no unintended glob/word splitting,
  - unchanged-output path does not retouch the flag,
  - changed-output path retouches the flag,
  - old output file is removed in both compare paths.

###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add @microsoft/cbl-mariner-multi-package-reviewers team as reviewer (Eg. golang has 2 versions 1.18, 1.21+)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Harden toolkit/scripts/update-target-if-output-changed.sh by quoting path expansions and using operand separators to prevent shell word splitting/glob expansion issues flagged by SAST.

###### Change Log  <!-- REQUIRED -->
- Quote path variables in file-existence checks and command invocations.
- Add `--` before positional path operands for `touch`, `cmp`, and `rm`.
- Preserve script behavior while eliminating unsafe expansion patterns.

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
- N/A

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
- `bash -n toolkit/scripts/update-target-if-output-changed.sh`
- Local shell execution with temporary files containing spaces and wildcard characters to validate unchanged/changed comparison branches and old-file cleanup

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/0618d181-926b-4f3d-a7f4-25b58bca7f34)

Comment @datadog to request changes