### PR TITLE
Harden kdump SSH command operand quoting

### DIFF
--- a/SPECS/kexec-tools/dracut-kdump.sh
+++ b/SPECS/kexec-tools/dracut-kdump.sh
@@ -176,25 +176,16 @@ save_vmcore_dmesg_ssh() {
     local _dmesg_collector=$1
     local _path=$2
     local _opts="$3"
-    local _location=$4 dd/fix/kdump-ssh-command-escaping
-    local _dmesg_incomplete_path="${_path}/vmcore-dmesg-incomplete.txt"
-    local _dmesg_path="${_path}/vmcore-dmesg.txt"
-    local _dmesg_incomplete_path_escaped=$(printf "%s" "$_dmesg_incomplete_path" | sed "s/'/'\\\\''/g")
-    local _dmesg_path_escaped=$(printf "%s" "$_dmesg_path" | sed "s/'/'\\\\''/g")
-    local _remote_dd_cmd=$(printf "dd of='%s'" "$_dmesg_incomplete_path_escaped")
-    local _remote_mv_cmd=$(printf "mv '%s' '%s'" "$_dmesg_incomplete_path_escaped" "$_dmesg_path_escaped")
+    local _location=$4
+    local _dmesg_incomplete_remote=$(quote_for_remote_shell "${_path}/vmcore-dmesg-incomplete.txt")
+    local _dmesg_remote=$(quote_for_remote_shell "${_path}/vmcore-dmesg.txt")
 
     echo "kdump: saving vmcore-dmesg.txt"
-    $_dmesg_collector /proc/vmcore | ssh $_opts "$_location" "$_remote_dd_cmd"
-    local _remote_dmesg_path
-
-    echo "kdump: saving vmcore-dmesg.txt"
-    _remote_dmesg_path=$(printf "%s/vmcore-dmesg-incomplete.txt" "$_path" | sed "s/'/'\\\\''/g")
-    $_dmesg_collector /proc/vmcore | ssh $_opts $_location 'dd of='"'"$_remote_dmesg_path"'" 2.0
+    $_dmesg_collector /proc/vmcore | ssh $_opts "$_location" 'dd of='"$_dmesg_incomplete_remote"
     _exitcode=$?
 
     if [ $_exitcode -eq 0 ]; then
-        ssh -q $_opts "$_location" "$_remote_mv_cmd"
+        ssh -q $_opts "$_location" 'mv '"$_dmesg_incomplete_remote"' '"$_dmesg_remote"
         echo "kdump: saving vmcore-dmesg.txt complete"
     else
         echo "kdump: saving vmcore-dmesg.txt failed"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"f9a10f9a-2d6a-4334-a023-a358500526f8","source":"chat","resourceId":"e36fab9f-68a7-46d3-a574-5dc1ec79dab5","workflowId":"4c27e058-6428-4b0b-9d8b-61e58027da90","codeChangeId":"4c27e058-6428-4b0b-9d8b-61e58027da90","sourceType":"code_security_sast"} -->
###### Merge Checklist  <!-- REQUIRED -->

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/bf40e8738083c1d129f518240d53ea5c?panel_event_id=AwAAAZ8jDtklAImJXQAAABhBWjhqRHRrbEFBQjVNUnIzdENWeFVrNDIAAAAkZjE5ZjIzMGYtMTQ2My00NmU2LTgyNjMtMzE5ZTM5YTY5NjFmAAAG5A&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22YmY0MGU4NzM4MDgzYzFkMTI5ZjUxODI0MGQ1M2VhNWN-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22+%22This+double-quoted+ssh+operand+%28the+last+one%29+expands+variables+and+command+substitutions+on+the+client+before+the+remote+shell+runs%3B+use+single+quotes+for+remote+text+or+escape+%24+when+expansion+must+stay+local%22)

**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
This change addresses a critical SAST finding in the kdump SSH dmesg upload flow by removing double-quoted remote command operands and using shell-quoted remote paths. This prevents accidental client-side interpretation of remote command content and keeps remote execution behavior explicit.

###### Change Log  <!-- REQUIRED -->
- Updated `save_vmcore_dmesg_ssh` in `SPECS/kexec-tools/dracut-kdump.sh` to use `quote_for_remote_shell` for both remote dmesg paths.
- Replaced `ssh ... "$_remote_mv_cmd"` style execution with single-quoted remote command text plus pre-quoted path arguments.
- Removed stale/conflicted intermediate command-building lines in the same function and kept one consistent command path for writing and renaming `vmcore-dmesg` remotely.

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
- N/A

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
- Ran `bash -n SPECS/kexec-tools/dracut-kdump.sh`
- Verified the target function no longer passes a double-quoted remote command operand to `ssh`

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/e36fab9f-68a7-46d3-a574-5dc1ec79dab5)

Comment @datadog to request changes