### PR TITLE
Quote guice version variable in tarball script

### DIFF
--- a/SPECS/google-guice/create_source_tarball.sh
+++ b/SPECS/google-guice/create_source_tarball.sh
@@ -63,7 +63,7 @@ cd tarball-tmp
 tar xf "../${name}-${version}.orig.tar.gz"
 
 # CLEAN TARBALL
-cd ./guice-$version
+cd "./guice-$version"
 rm -rf $(ls . | grep -E -v 'core|extensions|pom|bom|jdk8-tests|COPYING|common.xml')
 find . -name "*.jar" -delete
 find . -name "*.class" -delete


### PR DESCRIPTION
<!-- dd-meta {"pullId":"e4fbbfd8-fe61-4ce1-a624-a19a5dde5b87","source":"chat","resourceId":"3d2034f4-ff20-4961-8ff5-990b434208de","workflowId":"27fafdb6-aeb6-47a0-b113-495b911acd35","codeChangeId":"27fafdb6-aeb6-47a0-b113-495b911acd35","sourceType":"code_security_sast"} -->
###### Merge Checklist  <!-- REQUIRED -->

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/549d7ce6144de1783344a5af7369e514?panel_event_id=AwAAAZ8jDuX1NytwegAAABhBWjhqRHVYMUFBRE8xbENYQm05TFNlcmMAAAAkZjE5ZjIzMGUtZjc0ZS00ODljLTllOGYtZTlhNTdiMzFlZDg4AAAAKQ&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22NTQ5ZDdjZTYxNDRkZTE3ODMzNDRhNWFmNzM2OWU1MTR-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22+%22Double+quote+variable+expansions+to+prevent+word+splitting+and+glob+expansion%22)

**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
This change addresses a high-severity SAST finding in `SPECS/google-guice/create_source_tarball.sh` by hardening the `cd` path construction so an unquoted package version value cannot trigger shell word splitting or glob expansion.

###### Change Log  <!-- REQUIRED -->
- Updated the directory change from `cd ./guice-$version` to `cd "./guice-$version"` in `SPECS/google-guice/create_source_tarball.sh`.
- Preserved existing script behavior while ensuring the version variable is treated as a single path token.
- Reduced shell-injection-adjacent risk and improved robustness for unexpected version input.

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
- N/A

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
- Ran `bash -n SPECS/google-guice/create_source_tarball.sh`

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/3d2034f4-ff20-4961-8ff5-990b434208de)

Comment @datadog to request changes