### PR TITLE
Quote version expansion in guice script

### DIFF
--- a/SPECS/google-guice/create_source_tarball.sh
+++ b/SPECS/google-guice/create_source_tarball.sh
@@ -63,7 +63,7 @@ cd tarball-tmp
 tar xf "../${name}-${version}.orig.tar.gz"
 
 # CLEAN TARBALL
-cd ./guice-$version
+cd "./guice-${version}"
 rm -rf $(ls . | grep -E -v 'core|extensions|pom|bom|jdk8-tests|COPYING|common.xml')
 find . -name "*.jar" -delete
 find . -name "*.class" -delete


### PR DESCRIPTION
<!-- dd-meta {"pullId":"da903bae-a382-462a-a1a7-fd414a9cdd17","source":"chat","resourceId":"f7f12906-f3ee-4cf3-8f58-c644917bb439","workflowId":"2296755d-b06d-459f-9376-2993dcc28c3f","codeChangeId":"2296755d-b06d-459f-9376-2993dcc28c3f","sourceType":"code_security_sast"} -->
###### Motivation

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/549d7ce6144de1783344a5af7369e514?panel_event_id=AwAAAZ8jDuX1NytwegAAABhBWjhqRHVYMUFBRE8xbENYQm05TFNlcmMAAAAkZjE5ZjIzMGUtZjc0ZS00ODljLTllOGYtZTlhNTdiMzFlZDg4AAAAKQ&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22NTQ5ZDdjZTYxNDRkZTE3ODMzNDRhNWFmNzM2OWU1MTR-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22+%22Double+quote+variable+expansions+to+prevent+word+splitting+and+glob+expansion%22)

Prevent word splitting and glob expansion in the google-guice source tarball helper script by quoting a user-provided version expansion used in a path operation.

###### Changes
- Updated SPECS/google-guice/create_source_tarball.sh to quote the version expansion in the `cd` command (`cd "./guice-${version}"`).
- Kept the script behavior unchanged for normal version values while hardening handling of unexpected whitespace/glob characters.

###### Testing
- Ran `bash -n SPECS/google-guice/create_source_tarball.sh`.
- Attempted to run `shellcheck`, but it is not installed in this sandbox.

###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add @microsoft/cbl-mariner-multi-package-reviewers team as reviewer (Eg. golang has 2 versions 1.18, 1.21+)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
What does the PR accomplish, why was it needed?

This PR fixes a high-severity shell SAST finding by quoting a variable expansion that was used unquoted in a `cd` path, preventing unsafe shell word splitting/glob expansion.

###### Change Log  <!-- REQUIRED -->
- Quote `${version}` in the guice source directory `cd` path in SPECS/google-guice/create_source_tarball.sh.
- Preserve existing tarball creation behavior for normal package versions.
- Address rule `bash-security/double-quote-variable-expansions` for the reported location.

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
- N/A

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
- Local validation in sandbox: `bash -n SPECS/google-guice/create_source_tarball.sh`

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/f7f12906-f3ee-4cf3-8f58-c644917bb439)

Comment @datadog to request changes