### PR TITLE
Fix unsafe sodiff repoquery arg expansion

### DIFF
--- a/toolkit/scripts/sodiff/mariner-sodiff.sh
+++ b/toolkit/scripts/sodiff/mariner-sodiff.sh
@@ -14,11 +14,11 @@ mkdir -p "$sodiff_out_dir"
 
 # Prepare mariner/ubuntu compatibility calls
 
-common_options="-c $repo_file_path --releasever $mariner_version"
+common_options=(-c "$repo_file_path" --releasever "$mariner_version")
 
 DNF_COMMAND=dnf
 # Cache RPM metadata
->/dev/null dnf $common_options -y makecache
+>/dev/null dnf "${common_options[@]}" -y makecache
 
 # Get packages from stdin
 pkgs=`cat`
@@ -30,7 +30,7 @@ for rpmpackage in $pkgs; do
     echo ".so's provided: $package_provides"
     for sofile in $package_provides; do
         # Query local metadata for provides
-        sos_found=$( 2>/dev/null $DNF_COMMAND repoquery $common_options --whatprovides $sofile | wc -l )
+        sos_found=$(2>/dev/null "$DNF_COMMAND" repoquery "${common_options[@]}" --whatprovides "$sofile" | wc -l)
         echo "Number of .so files found: $sos_found"
         if [ "$sos_found" -eq 0 ] ; then
             # SO file not found, meaning this might be a new .SO
@@ -41,14 +41,14 @@ for rpmpackage in $pkgs; do
             sofile_no_ver=$(echo "$sofile" | sed -E 's/[.]so[(.].+/.so/')
 
             # check for generic .so in the repo
-            sos_found=$( 2>/dev/null $DNF_COMMAND repoquery $common_options --whatprovides "${sofile_no_ver}*" | wc -l )
+            sos_found=$(2>/dev/null "$DNF_COMMAND" repoquery "${common_options[@]}" --whatprovides "${sofile_no_ver}*" | wc -l)
             echo "Number of non-versioned .so files found: $sos_found"
             if ! [ "$sos_found" -eq 0 ] ; then
                 # Generic version of SO was found.
                 # This means it's a new version of a preexisting SO.
                 # Log which packages depend on this functionality
                 echo "Packages that require $sofile_no_ver:"
-                2>/dev/null $DNF_COMMAND repoquery $common_options -s --whatrequires "${sofile_no_ver}*" | sed -E 's/[.][^.]+[.]src[.]rpm//' | tee "$sodiff_out_dir"/"require_${sofile}"
+                2>/dev/null "$DNF_COMMAND" repoquery "${common_options[@]}" -s --whatrequires "${sofile_no_ver}*" | sed -E 's/[.][^.]+[.]src[.]rpm//' | tee "$sodiff_out_dir"/"require_${sofile}"
             fi
         fi
     done


### PR DESCRIPTION
<!-- dd-meta {"pullId":"037d77f6-7a8a-4586-adf5-467949f367ca","source":"chat","resourceId":"1f236a92-6de6-4fab-92d3-982da43a95e9","workflowId":"a2b8173c-689d-4c4c-94b6-902757b280e8","codeChangeId":"a2b8173c-689d-4c4c-94b6-902757b280e8","sourceType":"code_security_sast"} -->
###### Merge Checklist  <!-- REQUIRED -->

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/901912199a34f8fbb681c5150c308040?panel_event_id=AwAAAZ8jDuLsrkZ8ywAAABhBWjhqRHVMc0FBQUZLNFJ4dWFpblZZSGUAAAAkZjE5ZjIzMGUtZjc0ZS00ODljLTllOGYtZTlhNTdiMzFlZDg4AAAARQ&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22OTAxOTEyMTk5YTM0ZjhmYmI2ODFjNTE1MGMzMDgwNDB-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22+%22Double+quote+variable+expansions+to+prevent+word+splitting+and+glob+expansion%22)

**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
This PR addresses a high-severity SAST finding in `toolkit/scripts/sodiff/mariner-sodiff.sh` by removing unsafe unquoted variable expansion in DNF repoquery invocations. The previous implementation constructed `common_options` as a space-delimited string and passed it unquoted, which could trigger unintended word splitting and glob expansion.

###### Change Log  <!-- REQUIRED -->
- Converted `common_options` from a string to a Bash array so each option/value pair is passed as an explicit argument.
- Updated `dnf makecache` and `repoquery` calls to use `"${common_options[@]}"`.
- Quoted `"$sofile"` in `--whatprovides` to prevent shell word splitting and glob expansion in line with the SAST rule.

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
- N/A

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
- `bash -n toolkit/scripts/sodiff/mariner-sodiff.sh`
- Manual diff review to verify only argument handling changes were introduced.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/1f236a92-6de6-4fab-92d3-982da43a95e9)

Comment @datadog to request changes