### PR TITLE
Quote MAVENBINARY expansion in maven cache script

### DIFF
--- a/SPECS/maven/maven_build_caches.sh
+++ b/SPECS/maven/maven_build_caches.sh
@@ -75,7 +75,7 @@ function installUtils {
 	echo "Installing wget."
 	sudo tdnf install -y wget | dieIfError
 	pushd "/tmp"
-	wget $MAVENBINARY -O maven.rpm
+	wget "$MAVENBINARY" -O maven.rpm
 	echo "Installing pre-built PMC 1.0 maven rpm to provide maven binary needed to build maven itself."
 	sudo rpm -i --nodeps maven.rpm
 	mvn -v


### PR DESCRIPTION
<!-- dd-meta {"pullId":"d5506b13-c151-48c0-afaa-9d7c666e0cb6","source":"chat","resourceId":"9294bf38-259a-43b9-8b73-295ddcad3386","workflowId":"c86564f6-6971-4106-9340-03bcff9c3003","codeChangeId":"c86564f6-6971-4106-9340-03bcff9c3003","sourceType":"code_security_sast"} -->
###### Merge Checklist  <!-- REQUIRED -->

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/ac6b8c9b2663a1b8cf7c9a5d794d0c1d?panel_event_id=AwAAAZ8jDuX5KpylnwAAABhBWjhqRHVYNUFBQnBvYnFaSk9PYURoRmIAAAAkZjE5ZjIzMGUtZjc0ZS00ODljLTllOGYtZTlhNTdiMzFlZDg4AAAAJQ&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22YWM2YjhjOWIyNjYzYTFiOGNmN2M5YTVkNzk0ZDBjMWR-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22+%22Double+quote+variable+expansions+to+prevent+word+splitting+and+glob+expansion%22)

<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Fixes a high-severity shell quoting issue in the Maven cache helper script. `MAVENBINARY` is derived from script inputs and, when passed unquoted to `wget`, could be subject to word splitting or glob expansion that alters command arguments. Quoting the expansion keeps the URL as a single argument.

###### Change Log  <!-- REQUIRED -->
- Updated `SPECS/maven/maven_build_caches.sh` to use `wget "$MAVENBINARY" -O maven.rpm`.
- Kept the remediation minimal and localized to the flagged line to avoid behavior changes.
- Addresses SAST rule `bash-security/double-quote-variable-expansions` at line 78.

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
- N/A

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
- `bash -n SPECS/maven/maven_build_caches.sh`
- Confirmed the diff only introduces quoting for the `MAVENBINARY` expansion in `wget`.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/9294bf38-259a-43b9-8b73-295ddcad3386)

Comment @datadog to request changes