### PR TITLE
Harden run-parts variable quoting

### DIFF
--- a/SPECS/cronie/cronie.signatures.json
+++ b/SPECS/cronie/cronie.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
   "cronie-1.5.7.tar.gz": "538bcfaf2e986e5ae1edf6d1472a77ea8271d6a9005aee2497a9ed6e13320eb3",
-  "run-parts.sh": "7ed96cde9fa88c31316b397f4a2962d32ddc10e2a4dd08411adfe66f8a6b2881"
+  "run-parts.sh": "0b7db2a487b7e4b2ac94d4f1f41c45c5625716c8b640bc68c8e4b5584bcc9925"
  }
 }

--- a/SPECS/cronie/cronie.spec
+++ b/SPECS/cronie/cronie.spec
@@ -1,7 +1,7 @@
 Summary:        Cron Daemon
 Name:           cronie
 Version:        1.5.7
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        GPLv2+ AND MIT AND BSD AND ISC
 Vendor:         Microsoft Corporation
 Distribution:   Mariner

--- a/SPECS/cronie/run-parts.sh
+++ b/SPECS/cronie/run-parts.sh
@@ -36,13 +36,12 @@ for i in $(LC_ALL=C; echo $1/*[^~,]); do
 		if [ -r $1/whitelist ]; then
 			grep -q "^$(basename $i)$" $1/whitelist && continue
 		fi
-		logger -p cron.notice -t "run-parts[$$]" "($1) starting $(basename $i)"
+		logger -p cron.notice -t "run-parts[$$]" "($1) starting $(basename "$i")"
 		echo "${i}:"
 		echo 
-		$i 2>&1 
-		logger -i -p cron.notice -t "run-parts[$$]" "($1) finished $(basename $i)"
+		"$i" 2>&1 
+		logger -i -p cron.notice -t "run-parts[$$]" "($1) finished $(basename "$i")"
 	fi
 done
 
 exit 0
-


### PR DESCRIPTION
<!-- dd-meta {"pullId":"839fe638-16f7-42da-bf62-834c4ae4d4f0","source":"chat","resourceId":"bd27bd8b-109b-4209-950b-73eea44442d6","workflowId":"902cc843-2022-4dbd-a404-6c9470463846","codeChangeId":"902cc843-2022-4dbd-a404-6c9470463846","sourceType":"code_security_sast"} -->
###### Motivation

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/9dbb93832e52a870f03404ddfad3692e?panel_event_id=AwAAAZ8nwz0Zcs4KVQAAABhBWjhud3owWkFBQ2JQMmRuamZPelgzb2UAAAAkZjE5ZjI3YzUtMmExNS00NTY2LWFkMzgtMzlhZjliZWE1ZDg0AAAFIw&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22OWRiYjkzODMyZTUyYTg3MGYwMzQwNGRkZmFkMzY5MmV-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22+%22Double+quote+variable+expansions+to+prevent+word+splitting+and+glob+expansion%22)

Address a SAST finding in cronie's run-parts helper where an unquoted script path expansion could trigger word splitting and pathname expansion.

###### Changes
- Quoted the `basename` argument in run-parts start/finish logger messages.
- Quoted the executed script path (`"$i"`) to avoid shell word splitting/glob expansion when dispatching scripts.
- Updated `SPECS/cronie/cronie.signatures.json` with the new `run-parts.sh` SHA-256.
- Bumped `cronie` release to `4%{?dist}` in `SPECS/cronie/cronie.spec` for package update tracking.

###### Testing/Validation
- `bash -n SPECS/cronie/run-parts.sh`
- Verified the updated `run-parts.sh` hash matches `SPECS/cronie/cronie.signatures.json`.

###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
What does the PR accomplish, why was it needed?

This PR fixes a high-severity SAST issue in `SPECS/cronie/run-parts.sh` by properly quoting script path expansions used in execution and log messages.

###### Change Log  <!-- REQUIRED -->
- Updated `run-parts.sh` to quote `$i` when invoking `basename` in logger calls.
- Updated `run-parts.sh` to execute scripts using `"$i"`.
- Updated `cronie.signatures.json` to the new `run-parts.sh` hash.
- Incremented `Release` from `3` to `4` in `cronie.spec`.

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
- N/A

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
- Local syntax validation: `bash -n SPECS/cronie/run-parts.sh`

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/bd27bd8b-109b-4209-950b-73eea44442d6)

Comment @datadog to request changes