### PR TITLE
Quote basename args in addcerts script

### DIFF
--- a/toolkit/scripts/addcerts.sh
+++ b/toolkit/scripts/addcerts.sh
@@ -12,9 +12,9 @@ TLS_CERT=$2
 TLS_KEY=$3
 CA_CERT=$4
 USER_DATA_TEMP=$USER_DATA.tmp
-TLS_CERT_BASENAME=$(basename $TLS_CERT)
-TLS_KEY_BASENAME=$(basename $TLS_KEY)
-CA_CERT_BASENAME=$(basename $CA_CERT)
+TLS_CERT_BASENAME=$(basename -- "$TLS_CERT")
+TLS_KEY_BASENAME=$(basename -- "$TLS_KEY")
+CA_CERT_BASENAME=$(basename -- "$CA_CERT")
 
 while IFS= read -r line || [ -n "$line" ]; do
     echo $line


### PR DESCRIPTION
<!-- dd-meta {"pullId":"9e15641b-0b41-4994-a1fd-401a9695adfd","source":"chat","resourceId":"cbd376fe-2108-41e5-9c68-6ab6c6c04091","workflowId":"52361a98-a750-479a-b0a9-6854df5b098f","codeChangeId":"52361a98-a750-479a-b0a9-6854df5b098f","sourceType":"code_security_sast"} -->
###### Motivation

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/e5304e08b517b3778a980c3d7f9df83a?panel_event_id=AwAAAZ8nxvB8jCWBIQAAABhBWjhueHZCOEFBQmI2cHRBZlhWdjY4b1IAAAAkZjE5ZjI3YzctMjZiMy00YjZhLTliMGUtMDczNmQ3NWNhMzc3AAAGFg&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22ZTUzMDRlMDhiNTE3YjM3NzhhOTgwYzNkN2Y5ZGY4M2F-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22+%22Double+quote+variable+expansions+to+prevent+word+splitting+and+glob+expansion%22)

Address a high-severity SAST finding in `toolkit/scripts/addcerts.sh` where certificate path variables were expanded unquoted in `basename` calls, which could trigger word splitting or glob expansion for unexpected input values.

###### Changes
- Updated certificate basename extraction in `toolkit/scripts/addcerts.sh` to use `basename -- "$VAR"` for TLS cert, TLS key, and CA cert inputs.
- Kept the change scoped to argument handling only, without altering script behavior for normal inputs.

###### Testing
- `bash -n toolkit/scripts/addcerts.sh`

###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Quote certificate-path variable expansions in basename extraction to prevent shell word splitting and glob expansion.

###### Change Log  <!-- REQUIRED -->
- Quote `TLS_CERT`, `TLS_KEY`, and `CA_CERT` when calling `basename`.
- Add `--` to `basename` invocations to prevent option-style path values from being interpreted as flags.
- Keep all other script logic unchanged.

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
- N/A

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
- Local syntax validation: `bash -n toolkit/scripts/addcerts.sh`

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/cbd376fe-2108-41e5-9c68-6ab6c6c04091)

Comment @datadog to request changes