### PR TITLE
Quote pkgVersion echo in guice tarball script

### DIFF
--- a/SPECS/google-guice/create_source_tarball.sh
+++ b/SPECS/google-guice/create_source_tarball.sh
@@ -50,7 +50,7 @@ if [ -z "$PKG_VERSION" ]; then
     echo "--pkgVersion parameter cannot be empty"
     exit 1
 fi
-echo $PKG_VERSION
+echo "$PKG_VERSION"
 version=$PKG_VERSION
 
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"82583a5a-3b7a-4987-b8b6-5b824d54b287","source":"chat","resourceId":"8eb87330-d72e-40e2-87ab-f3022cbd4b71","workflowId":"57f6fbf5-6440-406b-b6c3-0e2c50e8c746","codeChangeId":"57f6fbf5-6440-406b-b6c3-0e2c50e8c746","sourceType":"code_security_sast"} -->
###### Merge Checklist  <!-- REQUIRED -->

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/a5d2681baa03e81f968124122d54ba18?panel_event_id=AwAAAZ8nvZ8QXLdotwAAABhBWjhudlo4UUFBQS16Tnpna0RMMGJhdjUAAAAkZjE5ZjI3YmUtMjI2ZS00ZGE2LTk0N2UtMGE1MmFmNGEwMTdhAAANcQ&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22YTVkMjY4MWJhYTAzZTgxZjk2ODEyNDEyMmQ1NGJhMTh-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22+%22Double+quote+variable+expansions+to+prevent+word+splitting+and+glob+expansion%22)

**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
This change fixes a shell expansion safety issue in the google-guice source tarball helper by quoting the `PKG_VERSION` echo expansion. Quoting prevents unintended word splitting and pathname expansion when `--pkgVersion` contains spaces or glob characters.

###### Change Log  <!-- REQUIRED -->
- Updated `SPECS/google-guice/create_source_tarball.sh` to use `echo "$PKG_VERSION"` instead of an unquoted variable expansion.
- Kept the fix minimal and scoped to the reported SAST finding at line 53.
- No package/version behavior was changed beyond safer shell argument handling.

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
- N/A

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
- `bash -n SPECS/google-guice/create_source_tarball.sh`

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/8eb87330-d72e-40e2-87ab-f3022cbd4b71)

Comment @datadog to request changes