### PR TITLE
Quote tarball vars in MariaDB script

### DIFF
--- a/SPECS/mariadb/generate_source_tarball.sh
+++ b/SPECS/mariadb/generate_source_tarball.sh
@@ -95,6 +95,6 @@ NEW_TARBALL="$OUT_FOLDER/$TARBALL_NAME"
 tar --sort=name --mtime="2021-11-10 00:00Z" \
     --owner=0 --group=0 --numeric-owner \
     --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
-    -zcf $NEW_TARBALL mariadb-$PKG_VERSION
+    -zcf "$NEW_TARBALL" "mariadb-$PKG_VERSION"
 
 echo "Source tarball $NEW_TARBALL successfully created!"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"ceccfdd2-a5b2-4a43-8dbe-5ba4ba4193ac","source":"chat","resourceId":"1a2d4ea7-4b31-4a45-8151-ec1bde676596","workflowId":"94576537-4510-4874-9ad0-59f0d57cf629","codeChangeId":"94576537-4510-4874-9ad0-59f0d57cf629","sourceType":"code_security_sast"} -->
###### Motivation

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/5b8fb92cd3113c4ebc62ff21b79f2f2e?panel_event_id=AwAAAZ8n0LuPCGHOWwAAABhBWjhuMEx1UEFBRGk2V2VXTUxnY2NsVk4AAAAkZjE5ZjI3ZDUtMjI0Ny00OTk5LTkxMjctNDgzZjY2OGEyZjU5AAAGoA&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22NWI4ZmI5MmNkMzExM2M0ZWJjNjJmZjIxYjc5ZjJmMmV-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22+%22Double+quote+variable+expansions+to+prevent+word+splitting+and+glob+expansion%22)

Address a high-severity SAST finding in the MariaDB source tarball helper script where unquoted variable expansion in the `tar` command could trigger word splitting or glob expansion when paths or version values contain special characters.

###### Changes
- Updated `SPECS/mariadb/generate_source_tarball.sh` to quote `NEW_TARBALL` in the `tar -zcf` invocation.
- Quoted the `mariadb-$PKG_VERSION` argument in the same `tar` command to keep argument boundaries intact.
- Kept the change minimal and scoped to the vulnerable command path.

###### Testing
- Ran `bash -n SPECS/mariadb/generate_source_tarball.sh` to validate script syntax after the change.

###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
This PR hardens MariaDB tarball generation by preventing shell word splitting/globbing in the output and source directory arguments passed to `tar`.

###### Change Log  <!-- REQUIRED -->
- Quote `NEW_TARBALL` in `tar -zcf`.
- Quote `mariadb-$PKG_VERSION` in `tar -zcf`.
- Affected package area: `SPECS/mariadb` helper script only.

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
- N/A

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
- Local validation: `bash -n SPECS/mariadb/generate_source_tarball.sh`

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/1a2d4ea7-4b31-4a45-8151-ec1bde676596)

Comment @datadog to request changes