### PR TITLE
Quote setup_functions path expansions

### DIFF
--- a/toolkit/scripts/containerized-build/resources/setup_functions.sh
+++ b/toolkit/scripts/containerized-build/resources/setup_functions.sh
@@ -35,7 +35,7 @@ rpm() {
                 SPEC=${SPEC%-*} #remove last suffix of type -*
                 SPEC=${SPEC%-*} #remove last suffix of type -*
                 SPEC=${SPEC%\**}
-                ln -sf $SPECS_DIR/$SPEC/* $SOURCES_DIR/
+                ln -sf "$SPECS_DIR/$SPEC"/* "$SOURCES_DIR/"
             fi
         done
     fi


### PR DESCRIPTION
<!-- dd-meta {"pullId":"7c190457-9c3b-4fdc-819e-4e7d0b1d86f6","source":"chat","resourceId":"42ea852f-5759-4f89-bf8f-9e65695f975c","workflowId":"434298f5-c37f-41ad-a882-21b07b05be1e","codeChangeId":"434298f5-c37f-41ad-a882-21b07b05be1e","sourceType":"code_security_sast"} -->
###### Merge Checklist  <!-- REQUIRED -->

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/ae6bbb59dafcd4339b453843e095e38a?panel_event_id=AwAAAZ8n8fgMYZhsTQAAABhBWjhuOGZnTUFBQ1VVT3VEUFJ6aktreTAAAAAkZjE5ZjI3ZjEtZmU1MC00MTcyLWFiYzAtMDM5ZmRmMTZjYjI5AAAASQ&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22YWU2YmJiNTlkYWZjZDQzMzliNDUzODQzZTA5NWUzOGF-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22+%22Double+quote+variable+expansions+to+prevent+word+splitting+and+glob+expansion%22)

**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Address a high-severity SAST finding in `setup_functions.sh` by safely quoting variable expansions used to construct `ln` arguments, preventing unsafe word splitting and unintended glob behavior when rpm-derived names include special characters.

###### Change Log  <!-- REQUIRED -->
- Updated the symlink creation command in `toolkit/scripts/containerized-build/resources/setup_functions.sh` to quote `$SPECS_DIR`, `$SPEC`, and `$SOURCES_DIR` expansions in the vulnerable path expression.
- Preserved intended source file globbing (`*`) while hardening variable handling against splitting and wildcard injection from variable values.
- Limited the fix to the flagged line for minimal behavioral impact.

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
- N/A

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
- Syntax-checked the rendered script by replacing `<TOPDIR>` with a temporary path and running `bash -n` on the result.
- Attempted linting via `shellcheck`; not available in this environment.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/42ea852f-5759-4f89-bf8f-9e65695f975c)

Comment @datadog to request changes