### PR TITLE
Fix unsafe line expansion in addcerts.sh

### DIFF
--- a/toolkit/scripts/addcerts.sh
+++ b/toolkit/scripts/addcerts.sh
@@ -17,9 +17,9 @@ TLS_KEY_BASENAME=$(basename -- "$TLS_KEY")
 CA_CERT_BASENAME=$(basename -- "$CA_CERT")
 
 while IFS= read -r line || [ -n "$line" ]; do
-    echo $line
+    echo "$line"
     echo "$line" >> $USER_DATA_TEMP
-    if  [ $line = "#cloud-config" ]; then
+    if [ "$line" = "#cloud-config" ]; then
         echo 'write_files:' >> $USER_DATA_TEMP
         # TLS_CERT
         echo '- encoding: gzip' >> $USER_DATA_TEMP


### PR DESCRIPTION
<!-- dd-meta {"pullId":"9b3100ed-638a-4907-a87d-27f22c725f63","source":"chat","resourceId":"a94a31ca-72b7-4509-bed7-c9c98e42fbc1","workflowId":"f4488198-9076-4093-8f88-ae7ea6a2d62d","codeChangeId":"f4488198-9076-4093-8f88-ae7ea6a2d62d","sourceType":"code_security_sast"} -->
###### Motivation

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/20c7bccd2fe72842d12db3600b1e017b?panel_event_id=AwAAAZ8n8fF5CczOxgAAABhBWjhuOGZGNUFBQ1ota0RGSDBWY0I4eDIAAAAkZjE5ZjI3ZjItN2U1ZC00ODYyLWE2M2ItZTViNjEwMzlkN2I0AAAEtA&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22MjBjN2JjY2QyZmU3Mjg0MmQxMmRiMzYwMGIxZTAxN2J-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22+%22Double+quote+variable+expansions+to+prevent+word+splitting+and+glob+expansion%22)

Fix a high-severity SAST finding in `toolkit/scripts/addcerts.sh` where unquoted expansion of a line read from user-provided data could trigger word splitting and glob expansion, causing incorrect output and unintended pathname expansion.

###### Changes
- Quoted `$line` in the logging echo within the user-data read loop.
- Quoted `$line` in the `#cloud-config` comparison to keep matching logic stable for lines with spaces or glob characters.
- Kept the change scoped to the vulnerable flow in `toolkit/scripts/addcerts.sh`.

###### Testing
- `bash -n toolkit/scripts/addcerts.sh`
- Ran `toolkit/scripts/addcerts.sh` with temporary user-data/cert/key/ca files and validated output contains `write_files:` plus expected certificate target paths.

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

Addresses a high-severity bash quoting issue in `toolkit/scripts/addcerts.sh` to prevent word splitting and glob expansion when processing lines from user data.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Quote `$line` in `echo` within the read loop.
- Quote `$line` in the `#cloud-config` condition check.
- No package or toolchain manifest changes.

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
NO

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- N/A

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- `bash -n toolkit/scripts/addcerts.sh`
- Local script execution with temporary input/certificate files; validated generated user-data includes `write_files:` and expected `/etc/tdnf/{tls.crt,tls.key,ca.crt}` paths.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/a94a31ca-72b7-4509-bed7-c9c98e42fbc1)

Comment @datadog to request changes