### PR TITLE
Quote sodiff .so iteration values

### DIFF
--- a/toolkit/scripts/sodiff/mariner-sodiff.sh
+++ b/toolkit/scripts/sodiff/mariner-sodiff.sh
@@ -26,10 +26,10 @@ pkgs=`cat`
 
 for rpmpackage in $pkgs; do
     package_path=$(find "$rpms_folder" -name "$rpmpackage" -type f)
-    package_provides=`2>/dev/null rpm -qP "$package_path" | grep -E '[.]so[(.]' `
+    mapfile -t package_provides < <(2>/dev/null rpm -qP "$package_path" | grep -E '[.]so[(.]')
     echo "Processing ${rpmpackage}..."
-    echo ".so's provided: $package_provides"
-    for sofile in $package_provides; do
+    echo ".so's provided: ${package_provides[*]}"
+    for sofile in "${package_provides[@]}"; do
         # Query local metadata for provides dd/fix/sodiff-quote-variable-expansions
         sos_found=$(2>/dev/null "$DNF_COMMAND" repoquery "${common_options[@]}" --whatprovides "$sofile" | wc -l)
         sos_found=$( 2>/dev/null "$DNF_COMMAND" repoquery "${common_options[@]}" --whatprovides "$sofile" | wc -l ) 2.0


### PR DESCRIPTION
<!-- dd-meta {"pullId":"723862a2-32e6-4571-a3be-4d40900a4fa7","source":"chat","resourceId":"b07c2be5-d5ee-4780-9b7f-6d818a83901f","workflowId":"169cf12e-cac3-4c87-9f94-fe3c00200313","codeChangeId":"169cf12e-cac3-4c87-9f94-fe3c00200313","sourceType":"code_security_sast"} -->
###### Motivation

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/98959082a1efdd31b886b1a63dddcba4?panel_event_id=AwAAAZ8n8fknUioQ1gAAABhBWjhuOGZrbkFBQXhWcEtTeERiQUhGMzAAAAAkZjE5ZjI3ZjItN2U1ZC00ODYyLWE2M2ItZTViNjEwMzlkN2I0AAAElw&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22OTg5NTkwODJhMWVmZGQzMWI4ODZiMWE2M2RkZGNiYTR-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22+%22Double+quote+variable+expansions+to+prevent+word+splitting+and+glob+expansion%22)

This change addresses a high-severity SAST finding in toolkit/scripts/sodiff/mariner-sodiff.sh where unquoted iteration over package-provided .so entries could trigger unintended word splitting and pathname expansion.

###### Changes
- Replaced command-substitution string capture of package_provides with a bash array populated via mapfile.
- Updated output logging to print the array safely.
- Updated the .so iteration loop to iterate with "${package_provides[@]}" so each provide is handled as an exact value.
- Kept the fix scoped to toolkit/scripts/sodiff/mariner-sodiff.sh.

###### Testing
- Ran: bash -n toolkit/scripts/sodiff/mariner-sodiff.sh
- Attempted linting with shellcheck; shellcheck is not installed in this environment.

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
What does the PR accomplish, why was it needed?

This PR fixes unsafe shell expansion in toolkit/scripts/sodiff/mariner-sodiff.sh when iterating package-provided shared library names, reducing the risk of incorrect matching and command behavior caused by word splitting or glob expansion.

###### Change Log  <!-- REQUIRED -->
- Converted package_provides to a mapfile-populated bash array.
- Switched loop iteration from unquoted scalar expansion to quoted array expansion.
- Updated logging to print array contents safely.

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
- N/A

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
- Local syntax validation: bash -n toolkit/scripts/sodiff/mariner-sodiff.sh

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/b07c2be5-d5ee-4780-9b7f-6d818a83901f)

Comment @datadog to request changes