### PR TITLE
Quote grpc checkout version expansions

### DIFF
--- a/SPECS/grpc/generate_source_tarball.sh
+++ b/SPECS/grpc/generate_source_tarball.sh
@@ -77,7 +77,7 @@ cd $TEMPDIR
 git clone --depth 1 https://github.com/grpc/grpc.git
 pushd grpc
 git fetch --all --tags
-git checkout tags/v$PKG_VERSION -b grpc-$PKG_VERSION
+git checkout "tags/v$PKG_VERSION" -b "grpc-$PKG_VERSION"
 git submodule update --init
 popd
 mv grpc/third_party third_party


### PR DESCRIPTION
<!-- dd-meta {"pullId":"493986d0-4ef6-47ef-b0db-66d6120fbe15","source":"chat","resourceId":"56fbec9b-cc73-44ce-94d8-1950fedb583f","workflowId":"84df70cc-32e4-42de-83f6-04fb4738670d","codeChangeId":"84df70cc-32e4-42de-83f6-04fb4738670d","sourceType":"code_security_sast"} -->
###### Motivation

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/b59d8a0d35f9698a18acfbd7d6dd23c3?panel_event_id=AwAAAZ8n8fQTKO5wtgAAABhBWjhuOGZRVEFBQlcxRWYwdFVFQjB4bUsAAAAkZjE5ZjI3ZjItN2U1ZC00ODYyLWE2M2ItZTViNjEwMzlkN2I0AAAEpQ&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22YjU5ZDhhMGQzNWY5Njk4YTE4YWNmYmQ3ZDZkZDIzYzN-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22+%22Double+quote+variable+expansions+to+prevent+word+splitting+and+glob+expansion%22)

Unquoted `PKG_VERSION` expansion in `SPECS/grpc/generate_source_tarball.sh` allowed word splitting and glob expansion when building the `git checkout` arguments. This could let crafted input alter checkout argument boundaries and produce unintended git behavior.

###### Changes
- Quoted the tag argument expansion in `git checkout` (`"tags/v$PKG_VERSION"`).
- Quoted the branch argument expansion in `git checkout` (`"grpc-$PKG_VERSION"`).
- Kept behavior otherwise unchanged for valid package versions.

###### Testing
- `bash -n SPECS/grpc/generate_source_tarball.sh`
- Attempted `shellcheck SPECS/grpc/generate_source_tarball.sh` (not available in this sandbox)

###### Merge Checklist
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary
This PR fixes a high-severity shell safety issue by quoting `PKG_VERSION` expansions in the grpc source tarball generation script, preventing word splitting and glob expansion in `git checkout` arguments.

###### Change Log
- Quote variable expansion for the checkout tag reference.
- Quote variable expansion for the checkout branch name.
- Preserve existing script flow and output behavior.

###### Does this affect the toolchain?
NO

###### Associated issues
- N/A

###### Links to CVEs
- N/A

###### Test Methodology
- Local syntax validation: `bash -n SPECS/grpc/generate_source_tarball.sh`
- ShellCheck could not be run because it is not installed in this environment

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/56fbec9b-cc73-44ce-94d8-1950fedb583f)

Comment @datadog to request changes