### PR TITLE
Quote build_pkg dependency argument

### DIFF
--- a/toolkit/scripts/containerized-build/resources/setup_functions.sh
+++ b/toolkit/scripts/containerized-build/resources/setup_functions.sh
@@ -49,7 +49,7 @@ build_pkg() {
     local PKG=("$@")
     if [ -z "$PKG" ]; then echo "Please provide pkg name"; return; fi
     rpm -ihv /mnt/INTERMEDIATE_SRPMS/$PKG*.src.rpm
-    install_dependencies $PKG
+    install_dependencies "$PKG"
     rpmbuild -ba $SPECS_DIR/$PKG/$PKG.spec
 }
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"31b268ec-d9a2-4f92-b042-1ff08906254b","source":"chat","resourceId":"9691dcf5-59a4-46d3-9c1b-1c17a0fc69ef","workflowId":"15629949-0ac2-45a9-999c-3d4e088eea0b","codeChangeId":"15629949-0ac2-45a9-999c-3d4e088eea0b","sourceType":"code_security_sast"} -->
###### Merge Checklist  <!-- REQUIRED -->

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/2befc92ffacd7190b43bba7a630c9c5a?panel_event_id=AwAAAZ8n8fOiNYUwuwAAABhBWjhuOGZPaUFBQmJNa2lnUk41VEFjbnEAAAAkZjE5ZjI3ZjEtZmU1MC00MTcyLWFiYzAtMDM5ZmRmMTZjYjI5AAAAeA&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22MmJlZmM5MmZmYWNkNzE5MGI0M2JiYTdhNjMwYzljNWF-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22+%22Double+quote+variable+expansions+to+prevent+word+splitting+and+glob+expansion%22)

**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
This change fixes a high-severity SAST finding (bash-security/double-quote-variable-expansions) in toolkit/scripts/containerized-build/resources/setup_functions.sh. In build_pkg(), the package name variable was forwarded to install_dependencies without quotes, which allowed shell word splitting and glob expansion if the input contained whitespace or glob characters.

###### Change Log  <!-- REQUIRED -->
- Updated build_pkg() to call install_dependencies with a quoted package argument.
- Replaced install_dependencies $PKG with install_dependencies "$PKG" at toolkit/scripts/containerized-build/resources/setup_functions.sh.
- Kept behavior unchanged for valid package names while removing unintended shell expansion risk.

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
- N/A

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
- Verified the file diff to ensure the fix is limited to the flagged line.
- Attempted bash syntax check; this template resource file contains placeholder tokens (e.g., <TOPDIR>) and is not directly parseable before templating.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/9691dcf5-59a4-46d3-9c1b-1c17a0fc69ef)

Comment @datadog to request changes