### PR TITLE
Quote macro dir for safe cd

### DIFF
--- a/toolkit/scripts/preparemacros.sh
+++ b/toolkit/scripts/preparemacros.sh
@@ -20,7 +20,7 @@ usage() {
 [ ! -d $2 ] && echo "Input rpm directory $2 does not exist" && usage
 
 mkdir -p -- "${dir}"
-cd ${dir}
+cd -- "${dir}"
 
 echo "Expanding rpms into MACRO_DIR ${dir}"
 while read p || [ -n "$p" ]; do


### PR DESCRIPTION
<!-- dd-meta {"pullId":"1f0d405a-2860-4133-bf04-c53a0dbb6482","source":"chat","resourceId":"b7629226-f2da-47ff-bfd2-e523db50438c","workflowId":"edb0b112-3ee3-4687-93b2-b0883b31d471","codeChangeId":"edb0b112-3ee3-4687-93b2-b0883b31d471","sourceType":"code_security_sast"} -->
###### Motivation

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/dea9cf0723ba11092b8f6f27799eac1f?panel_event_id=AwAAAZ9Gt-8Kg80_DQAAABhBWjlHdC04S0FBRDdha0tsS1N3STN0bHMAAAAkMDE5ZjQ2YmYtYzE3OS00MWQ5LWIwYmMtZGJiZDVhZDcyNDRhAACG9Q&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22ZGVhOWNmMDcyM2JhMTEwOTJiOGY2ZjI3Nzk5ZWFjMWZ-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

This addresses a high-severity SAST finding in toolkit/scripts/preparemacros.sh where an unquoted variable expansion was used in a directory change. Without quoting, values containing spaces, glob characters, or a leading dash can be misinterpreted due to word splitting/glob expansion or option parsing.

###### Changes
- Updated toolkit/scripts/preparemacros.sh to replace `cd ${dir}` with `cd -- "${dir}"`.
- Preserved existing behavior while making the directory argument safe and explicit.
- Kept the fix minimal and scoped to the reported finding location.

###### Testing
- Ran `bash -n toolkit/scripts/preparemacros.sh`.
- Reviewed the diff to confirm only the intended line changed.

###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Fixes a high-severity bash-security finding by making the macro directory `cd` operation safe against word splitting and glob expansion.

###### Change Log  <!-- REQUIRED -->
- Quote and option-guard the macro directory when changing directories.
- Maintain existing script flow and output behavior.
- Scope changes to the reported vulnerable line only.

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
- None

###### Links to CVEs  <!-- optional -->
- None

###### Test Methodology
- Local syntax validation with `bash -n toolkit/scripts/preparemacros.sh`

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/b7629226-f2da-47ff-bfd2-e523db50438c)

Comment @datadog to request changes