### PR TITLE
Quote tarball copy paths in kernel update script

### DIFF
--- a/toolkit/scripts/update_kernel.sh
+++ b/toolkit/scripts/update_kernel.sh
@@ -7,8 +7,8 @@ set -e
 
 # $1 = TARGET_SPEC
 function copy_local_tarball {
-    DESTINATION_FOLDER=$(dirname $1)
-    cp $DOWNLOAD_FILE_PATH $DESTINATION_FOLDER
+    DESTINATION_FOLDER=$(dirname -- "$1")
+    cp -- "$DOWNLOAD_FILE_PATH" "$DESTINATION_FOLDER"
 }
 
 # $1 = spec name
@@ -258,7 +258,7 @@ for spec in $SPECS
 do
     TARGET_SPEC=$WORKSPACE/SPECS/$spec/$spec.spec
     TARGET_SIGNATUREJSON=$WORKSPACE/SPECS/$spec/$spec.signatures.json
-    copy_local_tarball $TARGET_SPEC
+    copy_local_tarball "$TARGET_SPEC"
     update_spec $TARGET_SPEC
     update_signature $TARGET_SIGNATUREJSON
 done


### PR DESCRIPTION
<!-- dd-meta {"pullId":"152b0871-1b68-4331-9943-a57987f4beb6","source":"chat","resourceId":"a9e317f7-042b-487c-85d8-f0336ee710a2","workflowId":"d74ecb6d-509c-44dd-8cae-594cee824e33","codeChangeId":"d74ecb6d-509c-44dd-8cae-594cee824e33","sourceType":"code_security_sast"} -->
###### Motivation

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/ec5812f30cb3b65e868b8da6889083d5?panel_event_id=AwAAAZ9G6ebMwA3UggAAABhBWjlHNmViTUFBRDlDUmZJUThkX3U3U0oAAAAkMDE5ZjQ2ZjYtYWZlYy00NDMwLThmYTMtNzJmMDVjZTY2NTAyAABvHA&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22ZWM1ODEyZjMwY2IzYjY1ZTg2OGI4ZGE2ODg5MDgzZDV-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

Fix a high-severity SAST finding in the kernel update helper script: unquoted variable expansions in the tarball copy path could trigger word splitting or glob expansion when paths contain spaces or wildcard characters, causing incorrect file operations.

###### Changes
- Updated `copy_local_tarball` to resolve the destination directory with `dirname -- "$1"`.
- Updated the copy command to `cp -- "$DOWNLOAD_FILE_PATH" "$DESTINATION_FOLDER"` so source/destination are handled as single arguments.
- Updated the call site to `copy_local_tarball "$TARGET_SPEC"` to preserve the full spec path.

###### Testing
- `bash -n toolkit/scripts/update_kernel.sh`
- `shellcheck toolkit/scripts/update_kernel.sh` (not available in this environment)

###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
This change addresses a high-severity shell-safety finding in `toolkit/scripts/update_kernel.sh` by hardening path handling during tarball copy operations.

###### Change Log  <!-- REQUIRED -->
- Quote variable expansion in `dirname` within `copy_local_tarball`.
- Quote `cp` operands and add `--` safeguards.
- Quote the `copy_local_tarball` call argument at the call site.

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
- N/A

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
- Local syntax validation: `bash -n toolkit/scripts/update_kernel.sh`
- Local lint check attempted: `shellcheck` not installed in this environment

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/a9e317f7-042b-487c-85d8-f0336ee710a2)

Comment @datadog to request changes