### PR TITLE
Quote wget args in update_kernel.sh

### DIFF
--- a/toolkit/scripts/update_kernel.sh
+++ b/toolkit/scripts/update_kernel.sh
@@ -28,7 +28,7 @@ function download {
     mkdir -p $TMPDIR
     pushd $TMPDIR
     echo Downloading $FULL_URL
-    wget $FULL_URL -O $TARBALL_NAME
+    wget "$FULL_URL" -O "$TARBALL_NAME"
     # if [ $? -gt 0 ]; then
     #     echo "$FULL_URL failed to be reached. Does the version exist on CBL-Mariner-Linux-Kernel?"
     #     return 1


### PR DESCRIPTION
<!-- dd-meta {"pullId":"cccfcef5-1b5b-4f24-9c8c-4a9befacde27","source":"chat","resourceId":"4bf06298-9394-4cac-9921-f498afc9f1c2","workflowId":"0be98b86-8501-44fd-91e0-4bf099ee8920","codeChangeId":"0be98b86-8501-44fd-91e0-4bf099ee8920","sourceType":"code_security_sast"} -->
###### Motivation

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/320b812c6e2694e5b57a8e138f7fdcc0?panel_event_id=AwAAAZ9GwytxvsDb-wAAABhBWjlHd3l0eEFBRGlaTlFEdmJVNGY0TksAAAAkMDE5ZjQ2ZGItMzg0ZC00MzQzLWIzY2QtMWY3MDk1NmM1ZWYwAACGXA&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22MzIwYjgxMmM2ZTI2OTRlNWI1N2E4ZTEzOGY3ZmRjYzB-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

Fix a high-severity SAST finding in toolkit/scripts/update_kernel.sh where unquoted variable expansions in a wget command could allow word splitting and glob expansion.

###### Changes
- Quote FULL_URL and TARBALL_NAME in download() when invoking wget.
- Preserve existing behavior for valid inputs while hardening argument handling.

###### Testing
- bash -n toolkit/scripts/update_kernel.sh
- shellcheck is not available in this sandbox environment

###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Quote variable expansions in the wget invocation used by update_kernel.sh to prevent word splitting and glob expansion.

###### Change Log  <!-- REQUIRED -->
- Updated toolkit/scripts/update_kernel.sh download() to use quoted expansions in wget.
- Addressed SAST rule bash-security/double-quote-variable-expansions at line 31.
- No functional workflow changes beyond safer argument handling.

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
- N/A

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
- Local validation: bash -n toolkit/scripts/update_kernel.sh
- Static analysis check attempted: shellcheck not installed in sandbox

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/4bf06298-9394-4cac-9921-f498afc9f1c2)

Comment @datadog to request changes