### PR TITLE
Quote etcd source tarball argument

### DIFF
--- a/SPECS/etcd/generate_source_tarball.sh
+++ b/SPECS/etcd/generate_source_tarball.sh
@@ -85,7 +85,7 @@ NAME_VER="$PKG_NAME-$PKG_VERSION"
 VENDOR_TARBALL="$OUT_FOLDER/$NAME_VER-vendor.tar.gz"
 
 echo "Unpacking source tarball..."
-tar -xf $SRC_TARBALL
+tar -xf "$SRC_TARBALL"
 
 cd "$NAME_VER"
 echo "Get vendored modules"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"72d315a1-e83d-4f06-8645-32a948b69d39","source":"chat","resourceId":"53e7f61d-a307-482f-b60f-1c5d4164bee5","workflowId":"6e2ebffb-06c6-4637-9ea4-1dd79f2b0202","codeChangeId":"6e2ebffb-06c6-4637-9ea4-1dd79f2b0202","sourceType":"code_security_sast"} -->
###### Motivation

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/b1a8f7b5701dc06103d405c31ead7442?panel_event_id=AwAAAZ9GuFXIIXg6DwAAABhBWjlHdUZYSUFBQWc2UmFfcnBteGdSZG4AAAAkMDE5ZjQ2YmYtYzE3OS00MWQ5LWIwYmMtZGJiZDVhZDcyNDRhAACG5w&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22YjFhOGY3YjU3MDFkYzA2MTAzZDQwNWMzMWVhZDc0NDJ-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

The etcd source tarball generation script used an unquoted SRC_TARBALL expansion in a tar invocation. If the supplied path contains spaces or glob characters, the shell can perform word splitting or pathname expansion, which can change command arguments and make the script unsafe.

###### Changes
- Updated SPECS/etcd/generate_source_tarball.sh to quote SRC_TARBALL in the extraction command.
- Kept the script behavior the same for normal inputs while preventing splitting/globbing side effects.

###### Testing
- bash -n SPECS/etcd/generate_source_tarball.sh
- Ran repository Format and Lint tools (no formatter/linter configured for this bash file).

###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
This PR addresses a high-severity SAST finding in the etcd source tarball generation helper by quoting the tarball path expansion used by tar extraction.

###### Change Log  <!-- REQUIRED -->
- Quote SRC_TARBALL in SPECS/etcd/generate_source_tarball.sh tar extraction command to prevent word splitting and glob expansion.
- No package manifests or SPEC release tags were changed.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Associated issues  <!-- optional -->
- N/A

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
- Local syntax validation: bash -n SPECS/etcd/generate_source_tarball.sh

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/53e7f61d-a307-482f-b60f-1c5d4164bee5)

Comment @datadog to request changes