### PR TITLE
Quote local repo URL expansions in setup script

### DIFF
--- a/toolkit/scripts/containerized-build/resources/setup_functions.sh
+++ b/toolkit/scripts/containerized-build/resources/setup_functions.sh
@@ -96,8 +96,8 @@ enable_local_repo() {
     for urlWithPrefix in $baseurls
     do
         url="${urlWithPrefix#$prefixToRemove}" #remove 'file://' prefix
-        mkdir -p $url || { echo -e "\033[31m WARNING: Could not mkdir at $url, continuing\033[0m"; continue; }
-        pushd $url
+        mkdir -p "$url" || { echo -e "\033[31m WARNING: Could not mkdir at $url, continuing\033[0m"; continue; }
+        pushd "$url"
         createrepo .
         popd
         url_list+=" $url"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"fc1546c5-e011-4518-b65f-52af72843437","source":"chat","resourceId":"2476f3f6-5fda-43cb-a62f-a8f50f24bc74","workflowId":"64ca9f24-3019-4804-ab37-a5e3eae74525","codeChangeId":"64ca9f24-3019-4804-ab37-a5e3eae74525","sourceType":"code_security_sast"} -->
###### Merge Checklist  <!-- REQUIRED -->

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/1df92b9492f551295854e8da734d9770?panel_event_id=AwAAAZ9MBCSX2gHoSQAAABhBWjlNQkNTWEFBRGhkVjVFcHF6Zml3Mm4AAAAkZjE5ZjRjMDUtYTNkNy00ZTczLTk5ZGQtOGM2MWY4NzIzYTdmAAAF4g&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22MWRmOTJiOTQ5MmY1NTEyOTU4NTRlOGRhNzM0ZDk3NzB-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Fixes a high-severity SAST finding in the containerized build setup script by preventing shell word splitting and glob expansion when processing local repo base URLs.

###### Change Log  <!-- REQUIRED -->
- Quote `$url` when calling `mkdir -p` in `enable_local_repo`.
- Quote `$url` when calling `pushd` in `enable_local_repo`.
- Keep behavior unchanged for normal path values while hardening argument handling for unexpected path content.

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
- N/A

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
- Local syntax validation after substituting the template placeholder for `TOPDIR`:
  - `sed 's#<TOPDIR>#/tmp#g' toolkit/scripts/containerized-build/resources/setup_functions.sh > "$tmp" && bash -n "$tmp"`
- Manual diff review of `toolkit/scripts/containerized-build/resources/setup_functions.sh`.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/2476f3f6-5fda-43cb-a62f-a8f50f24bc74)

Comment @datadog to request changes