### PR TITLE
Harden influxdb tarball script quoting

### DIFF
--- a/SPECS/influxdb/generate_source_tarball.sh
+++ b/SPECS/influxdb/generate_source_tarball.sh
@@ -21,8 +21,8 @@ PARAMS=""
 while (( "$#" )); do
     case "$1" in
         --srcTarball)
-        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
-            SRC_TARBALL=$2
+        if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
+            SRC_TARBALL="$2"
             shift 2
         else
             echo "Error: Argument for $1 is missing" >&2
@@ -30,8 +30,8 @@ while (( "$#" )); do
         fi
         ;;
         --outFolder)
-        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
-            OUT_FOLDER=$2
+        if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
+            OUT_FOLDER="$2"
             shift 2
         else
             echo "Error: Argument for $1 is missing" >&2
@@ -39,8 +39,8 @@ while (( "$#" )); do
         fi
         ;;
         --pkgVersion)
-        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
-            PKG_VERSION=$2
+        if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
+            PKG_VERSION="$2"
             shift 2
         else
             echo "Error: Argument for $1 is missing" >&2
@@ -71,25 +71,25 @@ echo "-- create temp folder"
 tmpdir=$(mktemp -d)
 function cleanup {
     echo "+++ cleanup -> remove $tmpdir"
-    rm -rf $tmpdir
+    rm -rf "$tmpdir"
 }
 trap cleanup EXIT
 
 TARBALL_FOLDER="$tmpdir/tarballFolder"
-mkdir -p $TARBALL_FOLDER
-cp $SRC_TARBALL $tmpdir
+mkdir -p "$TARBALL_FOLDER"
+cp "$SRC_TARBALL" "$tmpdir"
 
-pushd $tmpdir > /dev/null
+pushd "$tmpdir" > /dev/null
 
 PKG_NAME="influxdb"
 NAME_VER="$PKG_NAME-$PKG_VERSION"
 VENDOR_TARBALL="$OUT_FOLDER/$NAME_VER-vendor.tar.gz"
 
 echo "Unpacking source tarball..."
-tar -xf $SRC_TARBALL
+tar -xf "$SRC_TARBALL"
 
 echo "Vendor go modules..."
-cd $NAME_VER
+cd "$NAME_VER"
 go mod vendor
 
 echo ""


### PR DESCRIPTION
<!-- dd-meta {"pullId":"eb0fa59c-1c39-49d2-8395-6304415a2362","source":"chat","resourceId":"ac0329ae-cf53-4c8a-84c6-917bdb2ecfa0","workflowId":"ca4adefa-b9c5-465c-a12f-56efb9e99eeb","codeChangeId":"ca4adefa-b9c5-465c-a12f-56efb9e99eeb","sourceType":"code_security_sast"} -->
###### Motivation

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/e44cff218f7315aeb896734848c65120?panel_event_id=AwAAAZ9G7N461lCsggAAABhBWjlHN040NkFBRGMwYkJReU1KZmx6cWcAAAAkMDE5ZjQ2ZjYtYWZlYy00NDMwLThmYTMtNzJmMDVjZTY2NTAyAABu8Q&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22ZTQ0Y2ZmMjE4ZjczMTVhZWI4OTY3MzQ4NDhjNjUxMjB-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

Address a high-severity SAST finding (`bash-security/double-quote-variable-expansions`) in `SPECS/influxdb/generate_source_tarball.sh`. The script accepted and propagated unquoted variable expansions in file/path operations, which can trigger word splitting or glob expansion when arguments (or `TMPDIR`) contain spaces or wildcard characters.

###### Changes
- Quoted argument assignments for `SRC_TARBALL`, `OUT_FOLDER`, and `PKG_VERSION` to preserve exact user-provided values.
- Quoted variable expansions used in path-sensitive commands: `rm`, `mkdir`, `cp`, `pushd`, `tar`, and `cd`.
- Quoted `${2:0:1}` checks in argument parsing to avoid unintended shell expansion behavior.

###### Testing
- `bash -n SPECS/influxdb/generate_source_tarball.sh`
- Ran repository `Format` and `Lint` automation tools (no shell formatter/linter auto-detected for this file).

###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
This PR hardens `SPECS/influxdb/generate_source_tarball.sh` against shell word splitting and glob expansion by consistently quoting variable expansions involved in argument parsing and filesystem operations.

###### Change Log  <!-- REQUIRED -->
- Quote parsed input assignments (`SRC_TARBALL`, `OUT_FOLDER`, `PKG_VERSION`).
- Quote path/file command arguments (`rm`, `mkdir`, `cp`, `pushd`, `tar`, `cd`).
- Quote first-character argument checks (`"${2:0:1}"`) in option validation.

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
- N/A

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
- Local validation: `bash -n SPECS/influxdb/generate_source_tarball.sh`
- Repository automation `Format`/`Lint`: no shell formatter/linter configured for this file.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/ac0329ae-cf53-4c8a-84c6-917bdb2ecfa0)

Comment @datadog to request changes