### PR TITLE
Harden rpm hydrate argument quoting

### DIFF
--- a/.pipelines/common/libs/build_tools.sh
+++ b/.pipelines/common/libs/build_tools.sh
@@ -30,7 +30,7 @@ hydrate_artifacts() {
     local repo_dir
     local rpms_archive
     local rpms_input
-    local rpms_dir
+    local rpms_dir=()
     local srpms_archive
     local srpms_input
     local toolchain_archive
@@ -41,7 +41,7 @@ hydrate_artifacts() {
     while getopts "cd:r:s:t:" OPTIONS
     do
         case "${OPTIONS}" in
-            c ) rpms_dir="RPMS_DIR=../build/rpms_cache/cache" ;;
+            c ) rpms_dir=("RPMS_DIR=../build/rpms_cache/cache") ;;
             d ) repo_dir="$OPTARG" ;;
             r ) rpms_input="$OPTARG" ;;
             s ) srpms_input="$OPTARG" ;;
@@ -102,7 +102,7 @@ hydrate_artifacts() {
     then
         echo "-- Hydrating cache of repo '$repo_dir' with RPMs from '$rpms_archive'."
 
-        sudo make -C "$toolkit_dir" -j"$(nproc)" hydrate-rpms PACKAGE_ARCHIVE="$rpms_archive" $rpms_dir
+        sudo make -C "$toolkit_dir" -j"$(nproc)" hydrate-rpms PACKAGE_ARCHIVE="$rpms_archive" "${rpms_dir[@]}"
         exit_code=$?
         if [[ $exit_code != 0 ]]; then
             echo "ERROR: failed to hydrate repo's RPMs." >&2


### PR DESCRIPTION
<!-- dd-meta {"pullId":"d47769e4-ede5-4139-9e11-e8715dfcd667","source":"chat","resourceId":"2de75cb6-d560-4b18-bb7e-c2b62e5715c7","workflowId":"967d31e1-1a5c-4958-a7d3-9fcb3b35305e","codeChangeId":"967d31e1-1a5c-4958-a7d3-9fcb3b35305e","sourceType":"code_security_sast"} -->
###### Motivation

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/5f8cc487c029c347611fc160672cf207?panel_event_id=AwAAAZ9Gu3AFloA18gAAABhBWjlHdTNBRkFBQm5JMDJRT0R5VGpSbGIAAAAkMDE5ZjQ2YmYtYzE3OS00MWQ5LWIwYmMtZGJiZDVhZDcyNDRhAACGsg&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22NWY4Y2M0ODdjMDI5YzM0NzYxMWZjMTYwNjcyY2YyMDd-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

Address a high-severity SAST finding in `.pipelines/common/libs/build_tools.sh` where an optional shell variable was expanded unquoted in a `make` command, which can lead to unsafe word splitting/glob expansion patterns.

###### Changes
- Changed `rpms_dir` from a scalar to an array so optional command arguments are represented safely.
- Updated the `-c` option handling to append the `RPMS_DIR=...` argument as a single array element.
- Updated the `hydrate-rpms` `make` invocation to use `"${rpms_dir[@]}"`, preserving omission when unset while preventing unsafe splitting/globbing.

###### Testing
- `bash -n .pipelines/common/libs/build_tools.sh`
- Attempted `shellcheck .pipelines/common/libs/build_tools.sh` (not available in this environment)

###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
This PR hardens the RPM hydration path by safely handling an optional `make` argument in `hydrate_artifacts`, resolving the reported shell expansion finding.

###### Change Log  <!-- REQUIRED -->
- Convert `rpms_dir` to an array-backed optional argument.
- Set cache override via array element when `-c` is passed.
- Use `"${rpms_dir[@]}"` in the `make` call to avoid unquoted expansion.

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
- N/A

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
- Local syntax validation with `bash -n .pipelines/common/libs/build_tools.sh`
- `shellcheck` unavailable in sandbox

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/2de75cb6-d560-4b18-bb7e-c2b62e5715c7)

Comment @datadog to request changes