### PR TITLE
Quote path vars in influx-cli tarball script

### DIFF
--- a/SPECS/influx-cli/generate_souce_tarball.sh
+++ b/SPECS/influx-cli/generate_souce_tarball.sh
@@ -71,25 +71,25 @@ echo "-- create temp folder"
 tmpdir=$(mktemp -d)
 function cleanup {
     echo "+++ cleanup -> remove $tmpdir"
-    rm -rf $tmpdir
+    rm -rf "$tmpdir"
 }
 trap cleanup EXIT
 
 TARBALL_FOLDER="$tmpdir/tarballFolder"
-mkdir -p $TARBALL_FOLDER
-cp $SRC_TARBALL $tmpdir
+mkdir -p "$TARBALL_FOLDER"
+cp "$SRC_TARBALL" "$tmpdir"
 
-pushd $tmpdir > /dev/null
+pushd "$tmpdir" > /dev/null
 
 PKG_NAME="influx-cli"
 NAME_VER="$PKG_NAME-$PKG_VERSION"
 VENDOR_TARBALL="$OUT_FOLDER/$NAME_VER-vendor.tar.gz"
 
 echo "Unpacking source tarball..."
-tar -xf $SRC_TARBALL
+tar -xf "$SRC_TARBALL"
 
 echo "Vendor go modules..."
-cd $NAME_VER
+cd "$NAME_VER"
 go mod vendor
 
 echo ""


### PR DESCRIPTION
<!-- dd-meta {"pullId":"5fee1f4e-9d32-426d-a495-a9965f7d6d6c","source":"chat","resourceId":"ec88bc4a-538c-4d2e-bb50-90e636f8b108","workflowId":"806b6d22-f67b-4f6e-b9eb-d38457b8f367","codeChangeId":"806b6d22-f67b-4f6e-b9eb-d38457b8f367","sourceType":"code_security_sast"} -->
###### Motivation (WHY)

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/08fef663d8774ac7166e7ae8a78086c4?panel_event_id=AwAAAZ9G1v_1mw5ShQAAABhBWjlHMXZfMUFBQUpIN1ZnVlNhOHJlZDkAAAAkMDE5ZjQ2ZGItMzg0ZC00MzQzLWIzY2QtMWY3MDk1NmM1ZWYwAACE5g&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22MDhmZWY2NjNkODc3NGFjNzE2NmU3YWU4YTc4MDg2YzR-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

A high-severity SAST finding reported unquoted variable expansion in the influx-cli source tarball helper script. Path variables in this script can contain whitespace or glob characters depending on runtime environment and invocation inputs, which can trigger word splitting or pathname expansion in shell commands.

###### Changes (WHAT)
- Quoted path variable expansions used in filesystem and archive commands within SPECS/influx-cli/generate_souce_tarball.sh.
- Updated cleanup, directory creation, copy, directory stack, extraction, and directory-change invocations to use quoted variables.
- Kept behavior unchanged while hardening shell argument handling for the flagged flow.

###### Testing (HOW verified)
- Ran syntax validation: bash -n SPECS/influx-cli/generate_souce_tarball.sh
- Reviewed git diff to confirm only targeted quoting changes were introduced.

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Harden shell argument handling in influx-cli tarball generation by quoting path-related variable expansions to prevent word splitting and glob expansion.

###### Change Log  <!-- REQUIRED -->
- Updated rm invocation in cleanup to quote tmpdir.
- Updated mkdir/cp/pushd/tar extraction commands to quote folder and tarball path variables.
- Updated cd invocation to quote NAME_VER before changing into the unpacked source directory.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Associated issues  <!-- optional -->
- N/A

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
- Local validation: bash -n SPECS/influx-cli/generate_souce_tarball.sh

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/ec88bc4a-538c-4d2e-bb50-90e636f8b108)

Comment @datadog to request changes