### PR TITLE
Quote srcTarball expansion in influx-cli script

### DIFF
--- a/SPECS/influx-cli/generate_souce_tarball.sh
+++ b/SPECS/influx-cli/generate_souce_tarball.sh
@@ -77,7 +77,7 @@ trap cleanup EXIT
 
 TARBALL_FOLDER="$tmpdir/tarballFolder"
 mkdir -p $TARBALL_FOLDER
-cp $SRC_TARBALL $tmpdir
+cp "$SRC_TARBALL" "$tmpdir"
 
 pushd $tmpdir > /dev/null
 
@@ -86,7 +86,7 @@ NAME_VER="$PKG_NAME-$PKG_VERSION"
 VENDOR_TARBALL="$OUT_FOLDER/$NAME_VER-vendor.tar.gz"
 
 echo "Unpacking source tarball..."
-tar -xf $SRC_TARBALL
+tar -xf "$SRC_TARBALL"
 
 echo "Vendor go modules..."
 cd $NAME_VER


### PR DESCRIPTION
<!-- dd-meta {"pullId":"ba8284f8-3743-45c8-acc1-0f911c386910","source":"chat","resourceId":"59f45d26-04ae-4ad3-a0c1-4803472dd73f","workflowId":"a7aac288-3d5e-4e1e-a982-1c6a7a815d23","codeChangeId":"a7aac288-3d5e-4e1e-a982-1c6a7a815d23","sourceType":"code_security_sast"} -->
###### Merge Checklist  <!-- REQUIRED -->

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/f6cc5b6467b2b3a2a4d3a8799ce5a79c?panel_event_id=AwAAAZ9HHVZeYpxRhQAAABhBWjlISFZaZUFBREZMVUhUSExFZTdJbTYAAAAkZjE5ZjQ3MWYtYTU5MS00Y2Q5LWEwYTEtNjM2MDM3NGQ0OTU4AABPJg&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22ZjZjYzViNjQ2N2IyYjNhMmE0ZDNhODc5OWNlNWE3OWN-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
This change fixes a high-severity bash-security SAST finding in SPECS/influx-cli/generate_souce_tarball.sh by preventing word splitting and glob expansion when handling the user-provided --srcTarball argument. The script previously expanded SRC_TARBALL unquoted in archive operations, which could split a single argument into multiple tokens and alter command behavior.

###### Change Log  <!-- REQUIRED -->
- Updated cp invocation to quote SRC_TARBALL and tmpdir paths.
- Updated tar extraction command to quote SRC_TARBALL.
- Scope of change is limited to SPECS/influx-cli/generate_souce_tarball.sh for influx-cli source tarball generation.

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
- N/A

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
- Ran: bash -n SPECS/influx-cli/generate_souce_tarball.sh

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/59f45d26-04ae-4ad3-a0c1-4803472dd73f)

Comment @datadog to request changes