### PR TITLE
Quote OUT_FOLDER realpath expansion

### DIFF
--- a/SPECS/numpy/generate_source_tarball.sh
+++ b/SPECS/numpy/generate_source_tarball.sh
@@ -61,7 +61,7 @@ if [ -z "$PKG_VERSION" ]; then
     echo "--pkgVersion parameter cannot be empty"
     exit 1
 fi
-OUT_FOLDER=$(realpath $OUT_FOLDER)
+OUT_FOLDER=$(realpath "$OUT_FOLDER")
 echo "-- create temp folder"
 TEMPDIR=$(mktemp -d)
 function cleanup {


### PR DESCRIPTION
<!-- dd-meta {"pullId":"9cebd544-2969-4b12-b5e1-29aba8e7e559","source":"chat","resourceId":"d4ae7ead-3ac3-417e-aa69-e8bf4dfb8c79","workflowId":"d09ba1d4-b584-4a45-80df-897f25ed6c38","codeChangeId":"d09ba1d4-b584-4a45-80df-897f25ed6c38","sourceType":"code_security_sast"} -->
###### Motivation

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/78a18a9de0a62bde7418708ce6883c6f?panel_event_id=AwAAAZ9HK4DQtgouAwAAABhBWjlISzREUUFBQ3h0R0FWb19kNVQzUVcAAAAkZjE5ZjQ3MmQtOWVmMC00NGNkLTljOWItMWU2NDhiNjUxZjRhAAADfg&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22NzhhMThhOWRlMGE2MmJkZTc0MTg3MDhjZTY4ODNjNmZ-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

Address a high-severity SAST finding in the numpy source tarball helper script where an unquoted variable expansion could trigger word splitting or glob expansion when `--outFolder` contains spaces or glob characters.

###### Changes
- Updated `SPECS/numpy/generate_source_tarball.sh` to quote `OUT_FOLDER` in the `realpath` invocation.
- This keeps argument handling safe and deterministic for paths with special characters while preserving existing behavior.

###### Testing
- `bash -n SPECS/numpy/generate_source_tarball.sh`
- `shellcheck SPECS/numpy/generate_source_tarball.sh` (not available in this environment)

###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Quotes the `OUT_FOLDER` expansion in the numpy source tarball generation script to prevent word splitting and glob expansion flagged by SAST.

###### Change Log  <!-- REQUIRED -->
- Updated `SPECS/numpy/generate_source_tarball.sh` to use `realpath "$OUT_FOLDER"`.
- Mitigates shell argument splitting/globbing risk for user-provided `--outFolder` values.
- No package versions, sources, or build logic were otherwise modified.

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
- N/A

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
- Local validation: `bash -n SPECS/numpy/generate_source_tarball.sh`
- Lint check availability: `shellcheck` not installed in sandbox

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/d4ae7ead-3ac3-417e-aa69-e8bf4dfb8c79)

Comment @datadog to request changes