### PR TITLE
Quote influxdb tarball extraction argument

### DIFF
--- a/SPECS/influxdb/generate_source_tarball.sh
+++ b/SPECS/influxdb/generate_source_tarball.sh
@@ -86,7 +86,7 @@ NAME_VER="$PKG_NAME-$PKG_VERSION"
 VENDOR_TARBALL="$OUT_FOLDER/$NAME_VER-vendor.tar.gz"
 
 echo "Unpacking source tarball..."
-tar -xf $SRC_TARBALL
+tar -xf -- "$SRC_TARBALL"
 
 echo "Vendor go modules..."
 cd $NAME_VER


### PR DESCRIPTION
<!-- dd-meta {"pullId":"2dcee825-782d-4e7e-a2d8-9f67cd824d31","source":"chat","resourceId":"f784b6b6-0707-4c6f-bede-b75684497c1c","workflowId":"00d22b0e-b4bc-4541-b868-94c5c13ff59f","codeChangeId":"00d22b0e-b4bc-4541-b868-94c5c13ff59f","sourceType":"code_security_sast"} -->
###### Motivation (WHY)

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/2501852f64ce62b250f6dc51d3d9cdee?panel_event_id=AwAAAZ9HD2nnUaz-GgAAABhBWjlIRDJubkFBREhnTUtwYmVmZ3U5bjAAAAAkZjE5ZjQ3MTAtY2E3Ni00NGFlLTgyYjUtZWIwZWNkZDE5N2VhAAAI1g&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22MjUwMTg1MmY2NGNlNjJiMjUwZjZkYzUxZDNkOWNkZWV-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

Fix a high-severity SAST finding in the influxdb source tarball generation script where an unquoted variable expansion could trigger shell word splitting and glob expansion during tar extraction.

###### Changes (WHAT)
- Updated SPECS/influxdb/generate_source_tarball.sh to quote the source tarball argument at extraction time.
- Added `--` before the tarball path in the `tar -xf` command to keep argument handling explicit and safe.

###### Testing (HOW verified)
- Ran `bash -n SPECS/influxdb/generate_source_tarball.sh` to validate script syntax after the change.

###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Quoted the source tarball argument in the influxdb tarball generation script to address unsafe shell expansion behavior and harden tar extraction argument handling.

###### Change Log  <!-- REQUIRED -->
- Updated tar extraction to use `tar -xf -- "$SRC_TARBALL"` in `SPECS/influxdb/generate_source_tarball.sh`

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
- N/A

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
- `bash -n SPECS/influxdb/generate_source_tarball.sh`

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/f784b6b6-0707-4c6f-bede-b75684497c1c)

Comment @datadog to request changes