### PR TITLE
Quote stage0 path in rust tarball script

### DIFF
--- a/SPECS/rust/generate_source_tarball.sh
+++ b/SPECS/rust/generate_source_tarball.sh
@@ -102,8 +102,8 @@ popd > /dev/null
 pushd $OUT_FOLDER > /dev/null
 echo "get additional src tarballs"
 CONFIG_FILE="$src_root/src/stage0.json"
-RUST_RELEASE_DATE=$(cat $CONFIG_FILE | jq -r '.compiler.date')
-RUST_STAGE0_VERSION=$(cat $CONFIG_FILE | jq -r '.compiler.version')
+RUST_RELEASE_DATE=$(jq -r '.compiler.date' "$CONFIG_FILE")
+RUST_STAGE0_VERSION=$(jq -r '.compiler.version' "$CONFIG_FILE")
 wget https://static.rust-lang.org/dist/$RUST_RELEASE_DATE/cargo-$RUST_STAGE0_VERSION-x86_64-unknown-linux-gnu.tar.xz
 wget https://static.rust-lang.org/dist/$RUST_RELEASE_DATE/rustc-$RUST_STAGE0_VERSION-x86_64-unknown-linux-gnu.tar.xz
 wget https://static.rust-lang.org/dist/$RUST_RELEASE_DATE/rust-std-$RUST_STAGE0_VERSION-x86_64-unknown-linux-gnu.tar.xz


### PR DESCRIPTION
<!-- dd-meta {"pullId":"3d856870-8159-43de-9f48-73c8027c0a3b","source":"chat","resourceId":"825f9351-9e0e-4fed-af8a-c39bc0a83358","workflowId":"7c157ab9-6bbc-4bbf-ba33-d7b9eff65722","codeChangeId":"7c157ab9-6bbc-4bbf-ba33-d7b9eff65722","sourceType":"code_security_sast"} -->
###### Merge Checklist  <!-- REQUIRED -->

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/c027db277e064f7ace2775712d9e7143?panel_event_id=AwAAAZ9HIyyJRpx1ZgAAABhBWjlISXl5SkFBQXpOOV9NMWZjTU15emIAAAAkMDE5ZjQ3MjMtY2U1NC00MTg3LTk0NjUtMWI3ZThjNTRlMjk5AAAEug&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22YzAyN2RiMjc3ZTA2NGY3YWNlMjc3NTcxMmQ5ZTcxNDN-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
This change addresses a high-severity SAST finding in the Rust source tarball generation script by eliminating an unquoted file-path variable expansion. The previous pattern could trigger word splitting or glob expansion if `--pkgVersion` produced a path containing shell metacharacters.

###### Change Log  <!-- REQUIRED -->
- Replaced `cat $CONFIG_FILE | jq -r '.compiler.date'` with `jq -r '.compiler.date' "$CONFIG_FILE"`.
- Replaced `cat $CONFIG_FILE | jq -r '.compiler.version'` with `jq -r '.compiler.version' "$CONFIG_FILE"`.
- Kept behavior intact while ensuring the config path is passed as a single argument.

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
- N/A

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
- Ran `bash -n SPECS/rust/generate_source_tarball.sh` to validate shell syntax.
- Manually reviewed the diff to confirm only the vulnerable unquoted expansions were changed.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/825f9351-9e0e-4fed-af8a-c39bc0a83358)

Comment @datadog to request changes