### PR TITLE
Quote kernel script path expansions

### DIFF
--- a/toolkit/scripts/update_kernel.sh
+++ b/toolkit/scripts/update_kernel.sh
@@ -7,8 +7,8 @@ set -e
 
 # $1 = TARGET_SPEC
 function copy_local_tarball {
-    DESTINATION_FOLDER=$(dirname $1)
-    cp $DOWNLOAD_FILE_PATH $DESTINATION_FOLDER
+    DESTINATION_FOLDER="$(dirname -- "$1")"
+    cp -- "$DOWNLOAD_FILE_PATH" "$DESTINATION_FOLDER"
 }
 
 # $1 = spec name


### PR DESCRIPTION
<!-- dd-meta {"pullId":"b528dd17-f1e9-44a0-93b8-b65d14d35149","source":"chat","resourceId":"505e7c50-9964-49c5-9720-33a213f872c2","workflowId":"ca3968f1-8457-41b8-9ab8-701d437252c9","codeChangeId":"ca3968f1-8457-41b8-9ab8-701d437252c9","sourceType":"code_security_sast"} -->
###### Motivation (WHY)

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/ec5812f30cb3b65e868b8da6889083d5?panel_event_id=AwAAAZ9G6ebMwA3UggAAABhBWjlHNmViTUFBRDlDUmZJUThkX3U3U0oAAAAkMDE5ZjQ2ZjYtYWZlYy00YTIxLThjZjEtNmE1YTc4OGNmZTc0AACF6Q&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22ZWM1ODEyZjMwY2IzYjY1ZTg2OGI4ZGE2ODg5MDgzZDV-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

Fix a high-severity SAST finding in `toolkit/scripts/update_kernel.sh` where unquoted variable expansion in `copy_local_tarball` could trigger word splitting or glob expansion when paths contain whitespace or wildcard characters.

###### Changes (WHAT)
- Quoted the positional parameter in the `dirname` call used to compute the destination folder.
- Quoted both source and destination path expansions in the `cp` command.
- Added `--` to `dirname` and `cp` invocations to avoid accidental option parsing from path values.

###### Testing (HOW verified)
- `bash -n toolkit/scripts/update_kernel.sh`

###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add @microsoft/cbl-mariner-multi-package-reviewers team as reviewer
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
This PR addresses a shell-safety issue in the kernel update helper script by hardening path handling in `copy_local_tarball`.

###### Change Log  <!-- REQUIRED -->
- Quote `$1` in `dirname -- "$1"` to prevent word splitting and pathname expansion.
- Quote `"$DOWNLOAD_FILE_PATH"` and `"$DESTINATION_FOLDER"` in `cp`.
- Use `--` with `cp` and `dirname` for safer argument parsing.

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
- N/A

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
- Local syntax validation: `bash -n toolkit/scripts/update_kernel.sh`

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/505e7c50-9964-49c5-9720-33a213f872c2)

Comment @datadog to request changes