### PR TITLE
Quote early-kdump initrd/kernel args

### DIFF
--- a/SPECS/kexec-tools/dracut-early-kdump.sh
+++ b/SPECS/kexec-tools/dracut-early-kdump.sh
@@ -50,7 +50,7 @@ early_kdump_load()
 
     $KEXEC ${EARLY_KEXEC_ARGS} $standard_kexec_args \
         --command-line="$EARLY_KDUMP_CMDLINE" \
-        --initrd=$EARLY_KDUMP_INITRD $EARLY_KDUMP_KERNEL
+        --initrd="$EARLY_KDUMP_INITRD" "$EARLY_KDUMP_KERNEL"
     if [ $? == 0 ]; then
         echo "kexec: loaded early-kdump kernel"
         return 0


### PR DESCRIPTION
<!-- dd-meta {"pullId":"246d5012-5a80-4239-9c0d-7952a3809b74","source":"chat","resourceId":"7f6d2d8d-b95e-492c-9d93-917345dd1acb","workflowId":"493aa503-136f-4e60-bc51-b7261b09a378","codeChangeId":"493aa503-136f-4e60-bc51-b7261b09a378","sourceType":"code_security_sast"} -->
###### Motivation

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/f275c23cf7f7ebe1522bc3cb96327437?panel_event_id=AwAAAZ9G_v8W2uCrnAAAABhBWjlHX3Y4V0FBQTduSVFmcVBnT2RZa04AAAAkMDE5ZjQ3MDctMTBhNS00NWNlLWFiMzMtZDNkNGMyMzA3YThhAAAHmQ&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22ZjI3NWMyM2NmN2Y3ZWJlMTUyMmJjM2NiOTYzMjc0Mzd-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

Fix a high-severity SAST finding in `dracut-early-kdump.sh` where unquoted variable expansion in the `kexec` call could trigger word splitting or glob expansion for path arguments.

###### Changes
- Quoted `EARLY_KDUMP_INITRD` in the `--initrd` argument.
- Quoted `EARLY_KDUMP_KERNEL` when passed as the kernel image path.
- Kept the change minimal and limited to the flagged call site.

###### Testing
- Ran `bash -n SPECS/kexec-tools/dracut-early-kdump.sh`.
- Manually reviewed the updated command invocation at the finding location.

###### Merge Checklist
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary
This PR fixes a shell quoting issue in early-kdump loading by ensuring kernel and initrd paths are passed to `kexec` as single, literal arguments.

###### Change Log
- Quote `EARLY_KDUMP_INITRD` in the `--initrd` argument.
- Quote `EARLY_KDUMP_KERNEL` positional path argument.
- Package affected: `kexec-tools` script `SPECS/kexec-tools/dracut-early-kdump.sh`.

###### Does this affect the toolchain?
NO

###### Associated issues
- N/A

###### Links to CVEs
- N/A

###### Test Methodology
- `bash -n SPECS/kexec-tools/dracut-early-kdump.sh`

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/7f6d2d8d-b95e-492c-9d93-917345dd1acb)

Comment @datadog to request changes