### PR TITLE
Quote shell vars in influxdb tarball script

### DIFF
--- a/SPECS/influxdb/generate_source_tarball.sh
+++ b/SPECS/influxdb/generate_source_tarball.sh
@@ -71,25 +71,25 @@ echo "-- create temp folder"
 tmpdir=$(mktemp -d)
 function cleanup {
     echo "+++ cleanup -> remove $tmpdir"
-    rm -rf $tmpdir
+    rm -rf "$tmpdir"
 }
 trap cleanup EXIT
 
 TARBALL_FOLDER="$tmpdir/tarballFolder"
-mkdir -p $TARBALL_FOLDER
-cp $SRC_TARBALL $tmpdir
+mkdir -p "$TARBALL_FOLDER"
+cp "$SRC_TARBALL" "$tmpdir"
 
-pushd $tmpdir > /dev/null
+pushd "$tmpdir" > /dev/null
 
 PKG_NAME="influxdb"
 NAME_VER="$PKG_NAME-$PKG_VERSION"
 VENDOR_TARBALL="$OUT_FOLDER/$NAME_VER-vendor.tar.gz"
 
 echo "Unpacking source tarball..."
-tar -xf $SRC_TARBALL
+tar -xf "$SRC_TARBALL"
 
 echo "Vendor go modules..."
-cd $NAME_VER
+cd "$NAME_VER"
 go mod vendor
 
 echo ""


### PR DESCRIPTION
<!-- dd-meta {"pullId":"9c605a75-7175-45d8-9b9d-78734fbd5f38","source":"chat","resourceId":"9b8d3277-7575-4d8c-a4eb-d958b3ea0cf1","workflowId":"317ac725-9d15-45d8-bb5c-60ac6a06c4aa","codeChangeId":"317ac725-9d15-45d8-bb5c-60ac6a06c4aa","sourceType":"code_security_sast"} -->
###### Motivation

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/e44cff218f7315aeb896734848c65120?panel_event_id=AwAAAZ9G7N461lCsggAAABhBWjlHN040NkFBRGMwYkJReU1KZmx6cWcAAAAkMDE5ZjQ2ZjYtYWZlYy00YTIxLThjZjEtNmE1YTc4OGNmZTc0AACFvg&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22ZTQ0Y2ZmMjE4ZjczMTVhZWI4OTY3MzQ4NDhjNjUxMjB-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

Fix a high-severity SAST finding in the InfluxDB source tarball helper by preventing shell word splitting and glob expansion when path variables are expanded.

###### Changes
- Added double quotes to variable expansions used as path arguments in `SPECS/influxdb/generate_source_tarball.sh`.
- Hardened cleanup and workspace operations (`rm`, `mkdir`, `cp`, `pushd`) against unsafe splitting behavior.
- Hardened archive extraction and directory navigation (`tar -xf`, `cd`) for paths with spaces or glob characters.

###### Testing/Validation
- Ran `bash -n SPECS/influxdb/generate_source_tarball.sh`.

---

###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
This PR addresses a shell-quoting weakness in the InfluxDB source tarball generation script so variable-expanded paths are handled safely and consistently.

###### Change Log  <!-- REQUIRED -->
- Quote `tmpdir` usage in cleanup and `pushd` operations.
- Quote path variables in `mkdir` and `cp` commands.
- Quote `SRC_TARBALL` and `NAME_VER` in `tar -xf` and `cd` commands.

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

###### Associated issues  <!-- optional -->
- N/A

###### Links to CVEs  <!-- optional -->
- N/A

###### Test Methodology
- `bash -n SPECS/influxdb/generate_source_tarball.sh`

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/9b8d3277-7575-4d8c-a4eb-d958b3ea0cf1)

Comment @datadog to request changes