### PR TITLE
Fix quoting in influx-cli tarball script

### DIFF
--- a/SPECS/influx-cli/generate_souce_tarball.sh
+++ b/SPECS/influx-cli/generate_souce_tarball.sh
@@ -21,8 +21,8 @@ PARAMS=""
 while (( "$#" )); do
     case "$1" in
         --srcTarball)
-        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
-            SRC_TARBALL=$2
+        if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
+            SRC_TARBALL="$2"
             shift 2
         else
             echo "Error: Argument for $1 is missing" >&2
@@ -30,8 +30,8 @@ while (( "$#" )); do
         fi
         ;;
         --outFolder)
-        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
-            OUT_FOLDER=$2
+        if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
+            OUT_FOLDER="$2"
             shift 2
         else
             echo "Error: Argument for $1 is missing" >&2
@@ -39,8 +39,8 @@ while (( "$#" )); do
         fi
         ;;
         --pkgVersion)
-        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
-            PKG_VERSION=$2
+        if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
+            PKG_VERSION="$2"
             shift 2
         else
             echo "Error: Argument for $1 is missing" >&2
@@ -71,25 +71,25 @@ echo "-- create temp folder"
 tmpdir=$(mktemp -d)
 function cleanup {
     echo "+++ cleanup -> remove $tmpdir"
-    rm -rf $tmpdir
+    rm -rf "$tmpdir"
 }
 trap cleanup EXIT
 
 TARBALL_FOLDER="$tmpdir/tarballFolder"
-mkdir -p $TARBALL_FOLDER
-cp $SRC_TARBALL $tmpdir
+mkdir -p "$TARBALL_FOLDER"
+cp "$SRC_TARBALL" "$tmpdir"
 
-pushd $tmpdir > /dev/null
+pushd "$tmpdir" > /dev/null
 
 PKG_NAME="influx-cli"
 NAME_VER="$PKG_NAME-$PKG_VERSION"
 VENDOR_TARBALL="$OUT_FOLDER/$NAME_VER-vendor.tar.gz"
 
 echo "Unpacking source tarball..."
-tar -xf $SRC_TARBALL
+tar -xf "$SRC_TARBALL"
 
 echo "Vendor go modules..."
-cd $NAME_VER
+cd "$NAME_VER"
 go mod vendor
 
 echo ""


### PR DESCRIPTION
<!-- dd-meta {"pullId":"70220839-527b-4374-ae33-aec0c9fbfbcb","source":"chat","resourceId":"ecead76c-05db-46b8-9ce6-33f4ef62e5b8","workflowId":"dfabc0b9-d5f7-4f7f-acb1-a233c5ba09a5","codeChangeId":"dfabc0b9-d5f7-4f7f-acb1-a233c5ba09a5","sourceType":"code_security_sast"} -->
### Motivation (WHY)

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/08fef663d8774ac7166e7ae8a78086c4?panel_event_id=AwAAAZ9G1v_1mw5ShQAAABhBWjlHMXZfMUFBQUpIN1ZnVlNhOHJlZDkAAAAkMDE5ZjQ2ZGItMzg0ZC00MzQzLWIzY2QtMWY3MDk1NmM1ZWYwAACE5g&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22MDhmZWY2NjNkODc3NGFjNzE2NmU3YWU4YTc4MDg2YzR-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

A high-severity SAST finding (`bash-security/double-quote-variable-expansions`) was reported for `SPECS/influx-cli/generate_souce_tarball.sh` at line 82. The script used unquoted variable expansions in command arguments, which can trigger word splitting and glob expansion when paths include whitespace or wildcard characters.

### Changes (WHAT)
- Quoted parameter parsing checks and assignments for `--srcTarball`, `--outFolder`, and `--pkgVersion`.
- Quoted filesystem and navigation command arguments that use variable-expanded paths (`rm -rf`, `mkdir -p`, `cp`, `pushd`, `tar -xf`, and `cd`).
- Fixed the specific flagged usage at line 82 by changing `pushd $tmpdir` to `pushd "$tmpdir"`.

### Testing (HOW verified)
- Ran `bash -n SPECS/influx-cli/generate_souce_tarball.sh` (passes).
- Attempted to run `shellcheck`, but it is not installed in this sandbox environment.

###### Merge Checklist
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary
This PR hardens `SPECS/influx-cli/generate_souce_tarball.sh` by quoting variable expansions used in command arguments so tarball paths and temporary directories are handled safely and consistently.

###### Change Log
- Quote argument substring checks and assignments for input parameters.
- Quote command arguments that consume variable-expanded paths.
- Resolve the reported high-severity SAST finding for unquoted expansion at line 82.

###### Does this affect the toolchain?
NO

###### Associated issues
- N/A

###### Links to CVEs
- N/A

###### Test Methodology
- Local validation: `bash -n SPECS/influx-cli/generate_souce_tarball.sh`
- Lint note: `shellcheck` is unavailable in this sandbox

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/ecead76c-05db-46b8-9ce6-33f4ef62e5b8)

Comment @datadog to request changes