### PR TITLE
Harden rust tarball extraction quoting

### DIFF
--- a/SPECS/rust/generate_source_tarball.sh
+++ b/SPECS/rust/generate_source_tarball.sh
@@ -83,7 +83,7 @@ mkdir -p $temp_cache
 
 pushd $src_folder > /dev/null
 echo "Unpacking source tarball..."
-tar -xf $SRC_TARBALL
+tar -xf -- "$SRC_TARBALL"
 popd > /dev/null
 
 pushd $src_root > /dev/null


### PR DESCRIPTION
<!-- dd-meta {"pullId":"3aa5677e-2886-48ce-a427-d4c6cee50dd4","source":"chat","resourceId":"0790cf21-1ec2-45b3-b876-aa74f11c8b11","workflowId":"253eeb4b-0e64-41c1-a757-ee441e6b55f3","codeChangeId":"253eeb4b-0e64-41c1-a757-ee441e6b55f3","sourceType":"code_security_sast"} -->
###### Merge Checklist  

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/769d6bcdda72f47e4c71be122797ead4?panel_event_id=AwAAAZ9rA_PrYmax6gAAABhBWjlyQV9QckFBQWNoT1VuajhhTlFCdFUAAAAkZjE5ZjZiMDgtNTUzZS00YjYxLTg4OWEtMTc2ZDQzMzA5MWM2AAAGNQ&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22NzY5ZDZiY2RkYTcyZjQ3ZTRjNzFiZTEyMjc5N2VhZDR-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary
Fixes a high-severity shell SAST issue in `SPECS/rust/generate_source_tarball.sh` by hardening how the source tarball path is passed to `tar`. This prevents unintended word splitting and glob expansion when `--srcTarball` contains spaces or wildcard characters.

###### Change Log
- Updated tar extraction to use `tar -xf -- "$SRC_TARBALL"`.
- Prevented word splitting and pathname expansion on the source tarball argument.
- Kept script behavior otherwise unchanged.

###### Does this affect the toolchain?
NO

###### Associated issues
- N/A

###### Links to CVEs
- N/A

###### Test Methodology
- `bash -n SPECS/rust/generate_source_tarball.sh`
- `shellcheck` not available in this sandbox environment

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/0790cf21-1ec2-45b3-b876-aa74f11c8b11)

Comment @datadog to request changes