### PR TITLE
Harden jsoup tarball spec glob

### DIFF
--- a/SPECS-EXTENDED/jsoup/generate-tarball.sh
+++ b/SPECS-EXTENDED/jsoup/generate-tarball.sh
@@ -2,7 +2,7 @@
 set -e
 
 name=jsoup
-version="$(sed -n 's/Version:\s*//p' *.spec)"
+version="$(sed -n 's/Version:\s*//p' ./*.spec)"
 
 # RETRIEVE
 wget "https://github.com/jhy/${name}/archive/${name}-${version}.tar.gz" -O "${name}-${version}.orig.tar.gz"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"27d4c7ef-c7e0-4098-bdc5-cefb3dc16fd2","source":"chat","resourceId":"2d490edf-7d35-4586-a7ef-b8a9e71200dd","workflowId":"8bcd3929-3d5a-4cb3-899f-b611cc1c0a08","codeChangeId":"8bcd3929-3d5a-4cb3-899f-b611cc1c0a08","sourceType":"code_security_sast"} -->
###### Summary <!-- REQUIRED -->

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/08312e03909a983b2b52f6b4a387534e?column=score&order=desc&panel_event_id=AwAAAZ_rAf1p-GwgGgAAABhBWl9yQWYxcEFBQXh5OHVVTVNUWmJQd3cAAAAkMTE5ZmViMmEtNzExOS00MWIwLTlmYzktMjRhODYzYjY1YmI0AAHWag)

Motivation: The jsoup tarball generation script passed a leading glob directly to sed. If a matching spec filename began with '-', sed could interpret it as an option rather than an input operand.

This PR hardens SPECS-EXTENDED/jsoup/generate-tarball.sh by prefixing the spec glob with './', preserving behavior while preventing option injection from glob expansion.

###### Change Log  <!-- REQUIRED -->
- Changes: Updated the jsoup tarball script to read the version from ./*.spec instead of *.spec.
- Affected package: jsoup.
- CVEs fixed: None.

###### Test Methodology
Testing: Verified the script parses with bash -n, confirmed the adjusted sed command still extracts the jsoup version, and ran git diff --check.
- Pipeline build id: N/A, local validation only.

###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/2d490edf-7d35-4586-a7ef-b8a9e71200dd)

Comment @datadog to request changes