### PR TITLE
Quote kdump mount target arguments

### DIFF
--- a/SPECS/kexec-tools/kdump-lib.sh
+++ b/SPECS/kexec-tools/kdump-lib.sh
@@ -241,47 +241,47 @@ get_target_from_path()
 {
     local _target
 
-    _target=$(df $1 2>/dev/null | tail -1 |  awk '{print $1}')
+    _target=$(df "$1" 2>/dev/null | tail -1 |  awk '{print $1}')
     [[ "$_target" == "/dev/root" ]] && [[ ! -e /dev/root ]] && _target=$(get_root_fs_device)
-    echo $_target
+    echo "$_target"
 }
 
 is_mounted()
 {
-    findmnt -k -n $1 &>/dev/null
+    findmnt -k -n "$1" &>/dev/null
 }
 
 get_mount_info()
 {
     local _info_type=$1 _src_type=$2 _src=$3; shift 3
-    local _info=$(findmnt --real -k -n -r -o $_info_type --$_src_type $_src $@)
+    local _info=$(findmnt --real -k -n -r -o "$_info_type" "--$_src_type" "$_src" "$@")
 
-    [ -z "$_info" ] && [ -e "/etc/fstab" ] && _info=$(findmnt --real -s -n -r -o $_info_type --$_src_type $_src $@)
+    [ -z "$_info" ] && [ -e "/etc/fstab" ] && _info=$(findmnt --real -s -n -r -o "$_info_type" "--$_src_type" "$_src" "$@")
 
-    echo $_info
+    echo "$_info"
 }
 
 get_fs_type_from_target()
 {
-    get_mount_info FSTYPE source $1 -f
+    get_mount_info FSTYPE source "$1" -f
 }
 
 get_mntopt_from_target()
 {
-    get_mount_info OPTIONS source $1 -f
+    get_mount_info OPTIONS source "$1" -f
 }
 # Find the general mount point of a dump target, not the bind mount point
 get_mntpoint_from_target()
 {
     # Expcilitly specify --source to findmnt could ensure non-bind mount is returned
-    get_mount_info TARGET source $1 -f
+    get_mount_info TARGET source "$1" -f
 }
 
 # Get the path where the target will be mounted in kdump kernel
 # $1: kdump target device
 get_kdump_mntpoint_from_target()
 {
-    local _mntpoint=$(get_mntpoint_from_target $1)
+    local _mntpoint=$(get_mntpoint_from_target "$1")
 
     # mount under /sysroot if dump to root disk or mount under
     # mount under /kdumproot if dump target is not mounted in first kernel
@@ -298,7 +298,7 @@ get_kdump_mntpoint_from_target()
     fi
 
     # strip duplicated "/"
-    echo $_mntpoint | tr -s "/"
+    echo "$_mntpoint" | tr -s "/"
 }
 
 # get_option_value <option_name>


### PR DESCRIPTION
<!-- dd-meta {"pullId":"42ba26f8-0259-4e58-9e13-c677190d3483","source":"chat","resourceId":"fcc22b7c-9631-4cf0-a0ad-8f06b476f4ba","workflowId":"f93f641a-7dc2-4133-8dc8-ec27841f1163","codeChangeId":"f93f641a-7dc2-4133-8dc8-ec27841f1163","sourceType":"code_security_sast"} -->
###### Summary <!-- REQUIRED -->

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/8456ede3981206bc2c10545026ee0f53?panel_event_id=AwAAAZ_htACKoWvzfgAAABhBWl9odEFDS0FBQkdxd3h6TkZ5WlVXTV8AAAAkMTE5ZmUxYjYtMGQ4MC00OGY0LTgxNmUtNTYwZjMwMGU0MTFkAAAEFA&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22ODQ1NmVkZTM5ODEyMDZiYzJjMTA1NDUwMjZlZTBmNTN-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

<!-- Quick explanation of the changes. -->
Quotes kdump mount target and source argument expansions so device paths or mount points containing whitespace or glob characters are passed to `findmnt` as single arguments. This addresses the SAST finding for unquoted expansion in `SPECS/kexec-tools/kdump-lib.sh`.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Quote the target path passed through `get_mntpoint_from_target`, `get_mount_info`, and adjacent kdump mount helpers.
- Quote returned helper values before printing or piping them to avoid word splitting and glob expansion.
- Preserve additional `findmnt` arguments with `"$@"`.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Ran `bash -n SPECS/kexec-tools/kdump-lib.sh`.
- Ran `sh -n SPECS/kexec-tools/kdump-lib.sh`.
- Ran `git diff --check`.
- Ran a focused bash harness that sources `kdump-lib.sh`, stubs `findmnt`, and verifies `/dev/disk/by-label/dump target` is received as one argument.

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/fcc22b7c-9631-4cf0-a0ad-8f06b476f4ba)

Comment @datadog to request changes