### PR TITLE
Quote kdump dracut args guard

### DIFF
--- a/SPECS/kexec-tools/kdump-lib.sh
+++ b/SPECS/kexec-tools/kdump-lib.sh
@@ -465,7 +465,7 @@ is_wdt_mod_omitted() {
 	local ret=1
 
 	dracut_args=$(grep  "^dracut_args" /etc/kdump.conf)
-	[[ -z $dracut_args ]] && return $ret
+	[[ -z "$dracut_args" ]] && return "$ret"
 
 	eval set -- $dracut_args
 	while :; do


### PR DESCRIPTION
<!-- dd-meta {"pullId":"038cc777-5f92-4026-a3ed-2df34ddb40d7","source":"chat","resourceId":"5a97177e-84d5-4fd0-acb4-82e8238e0b81","workflowId":"00a6f2d3-2f90-4632-8f3a-503bed01bed9","codeChangeId":"00a6f2d3-2f90-4632-8f3a-503bed01bed9","sourceType":"code_security_sast"} -->
###### Summary <!-- REQUIRED -->

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/833f84983ac059a894be4ce8a1e8a967?panel_event_id=AwAAAZ_htYsO5G8fBwAAABhBWl9odFlzT0FBQkh0emdNWTc2Nlg3SU4AAAAkMTE5ZmUxYjYtMGQ4MC00OGY0LTgxNmUtNTYwZjMwMGU0MTFkAAAD8A&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22ODMzZjg0OTgzYWMwNTlhODk0YmU0Y2U4YTFlOGE5Njd-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

Quote the empty dracut_args guard in SPECS/kexec-tools/kdump-lib.sh so the high-severity bash-security/double-quote-variable-expansions finding is cleared. The exact expansion is inside a Bash [[ ... ]] test, where word splitting and glob expansion are not performed, but quoting the expansion makes the guard explicit and keeps the analyzer from reporting it without changing control flow.

###### Change Log  <!-- REQUIRED -->
- Quote the dracut_args operand in the is_wdt_mod_omitted empty check.
- Quote the ret return value used by the same early return guard.

###### Test Methodology
- bash -n SPECS/kexec-tools/kdump-lib.sh
- git diff --check

###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/5a97177e-84d5-4fd0-acb4-82e8238e0b81)

Comment @datadog to request changes