### PR TITLE
Quote kdump bridge interface expansion

### DIFF
--- a/SPECS/kexec-tools/dracut-module-setup.sh
+++ b/SPECS/kexec-tools/dracut-module-setup.sh
@@ -233,7 +233,7 @@ kdump_setup_bridge() {
         fi
         _brif+="$_kdumpdev,"
     done
-    echo " bridge=$_netdev:$(echo $_brif | sed -e 's/,$//')" >> ${initdir}/etc/cmdline.d/41bridge.conf
+    echo " bridge=$_netdev:${_brif%,}" >> "${initdir}/etc/cmdline.d/41bridge.conf"
 }
 
 kdump_setup_bond() {


### PR DESCRIPTION
<!-- dd-meta {"pullId":"d405fb2f-587e-48a2-adb4-c3a11f6eb1a4","source":"chat","resourceId":"3a31240c-7f78-48c1-9e6b-32c452a6dc93","workflowId":"ed3b4736-3c4c-4722-8a3c-b660ac09c7b1","codeChangeId":"ed3b4736-3c4c-4722-8a3c-b660ac09c7b1","sourceType":"code_security_sast"} -->
###### Summary

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/897e1b95d145529876bbe4f6a8870f02?panel_event_id=AwAAAZ_htNtQSlmArQAAABhBWl9odE50UUFBRFdBSVVhLWhKR25VSjgAAAAkMTE5ZmUxYjYtMGQ4MC00OGY0LTgxNmUtNTYwZjMwMGU0MTFkAAAD_w&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22ODk3ZTFiOTVkMTQ1NTI5ODc2YmJlNGY2YTg4NzBmMDJ-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

Fixes a high-severity SAST finding in `SPECS/kexec-tools/dracut-module-setup.sh` where the generated kdump bridge interface list was expanded unquoted before trimming its trailing comma. The unquoted expansion could allow Bash word splitting or glob expansion to change the bridge command line output.

###### Change Log
- Replace the `echo $_brif | sed ...` command substitution with Bash suffix trimming via `${_brif%,}`.
- Quote the `41bridge.conf` redirection path on the touched line.

###### Test Methodology
- `bash -n SPECS/kexec-tools/dracut-module-setup.sh`
- `git diff --check`

---

###### Merge Checklist
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add @microsoft/cbl-mariner-multi-package-reviewers team as reviewer (Eg. golang has 2 versions 1.18, 1.21+)
- [x] Ready to merge

---

###### Does this affect the toolchain?
**NO**

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/3a31240c-7f78-48c1-9e6b-32c452a6dc93)

Comment @datadog to request changes