### PR TITLE
Quote mailx tarball path variables

### DIFF
--- a/SPECS-EXTENDED/mailx/get-upstream-tarball.sh
+++ b/SPECS-EXTENDED/mailx/get-upstream-tarball.sh
@@ -13,8 +13,8 @@
 
 newdir=new-upstream-tarball
 
-mkdir $newdir
-cd $newdir
+mkdir "$newdir"
+cd "$newdir"
 
 # checkout cvs
 echo "== Just press Enter =="
@@ -27,8 +27,7 @@ rm -rf nail/CVS nail/catd/CVS
 # find version in nail/version.c file defined as: #define V "xxx"
 ver=$(sed -rn 's/#define\s+V\s+\"([0-9.]+)\"/\1/p' nail/version.c)
 
-mv nail mailx-$ver
-tar cJf mailx-$ver.tar.xz mailx-$ver
+mv nail "mailx-$ver"
+tar cJf "mailx-$ver.tar.xz" "mailx-$ver"
 
-rm -rf mailx-$ver
-
+rm -rf "mailx-$ver"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"5824b6ce-bcb1-48e8-8bf3-7dcd279c6022","source":"chat","resourceId":"1d926f8b-ef8d-477c-b691-8b6d15f0414c","workflowId":"802333c6-0293-4bbc-9008-9dccf56272c6","codeChangeId":"802333c6-0293-4bbc-9008-9dccf56272c6","sourceType":"code_security_sast"} -->
###### Summary <!-- REQUIRED -->

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/a88fd0c9c00cab2dff603a12f6ec9bc7?panel_event_id=AwAAAZ_htXOi3ZZUlgAAABhBWl9odFhPaUFBQ0xaWFpoLW5tbkJGa1gAAAAkMTE5ZmUxYjYtMGQ4MC00OGY0LTgxNmUtNTYwZjMwMGU0MTFkAAAD8w&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22YTg4ZmQwYzljMDBjYWIyZGZmNjAzYTEyZjZlYzliYzd-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

Quote variable-derived path arguments in SPECS-EXTENDED/mailx/get-upstream-tarball.sh to address the high-severity SAST finding for possible word splitting and pathname expansion. The helper builds the mailx source tarball from CVS, so preserving each generated path as one shell argument avoids fragile behavior if values ever contain shell metacharacters or whitespace.

###### Change Log  <!-- REQUIRED -->
- Quote newdir in mkdir and cd.
- Quote mailx-$ver path arguments used by mv, tar, and rm.
- No package source, spec, signature, or toolchain content changed.

###### Test Methodology
- sh -n SPECS-EXTENDED/mailx/get-upstream-tarball.sh
- git diff --check
- ShellCheck was not run because shellcheck is not installed in this environment.
- Did not execute the helper because its normal flow requires CVS network access.

###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Associated issues  <!-- optional -->
- N/A

###### Links to CVEs  <!-- optional -->
- N/A

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/1d926f8b-ef8d-477c-b691-8b6d15f0414c)

Comment @datadog to request changes