### PR TITLE
Quote base container build arguments

### DIFF
--- a/.pipelines/containerSourceData/scripts/BuildBaseContainers.sh
+++ b/.pipelines/containerSourceData/scripts/BuildBaseContainers.sh
@@ -345,15 +345,15 @@ function save_container_image {
 function build_images {
     echo "+++ Build images"
 
-    docker_build $BASE "$BASE_IMAGE_NAME" "$BASE_TARBALL" "Dockerfile-Base-Template"
-    docker_build $DISTROLESS "$DISTROLESS_BASE_IMAGE_NAME" "$DISTROLESS_BASE_TARBALL" "Dockerfile-Distroless-Template"
-    docker_build $DISTROLESS "$DISTROLESS_MINIMAL_IMAGE_NAME" "$DISTROLESS_MINIMAL_TARBALL" "Dockerfile-Distroless-Template"
-    docker_build $DISTROLESS "$DISTROLESS_DEBUG_IMAGE_NAME" "$DISTROLESS_DEBUG_TARBALL" "Dockerfile-Distroless-Template"
+    docker_build "$BASE" "$BASE_IMAGE_NAME" "$BASE_TARBALL" "Dockerfile-Base-Template"
+    docker_build "$DISTROLESS" "$DISTROLESS_BASE_IMAGE_NAME" "$DISTROLESS_BASE_TARBALL" "Dockerfile-Distroless-Template"
+    docker_build "$DISTROLESS" "$DISTROLESS_MINIMAL_IMAGE_NAME" "$DISTROLESS_MINIMAL_TARBALL" "Dockerfile-Distroless-Template"
+    docker_build "$DISTROLESS" "$DISTROLESS_DEBUG_IMAGE_NAME" "$DISTROLESS_DEBUG_TARBALL" "Dockerfile-Distroless-Template"
 
-    docker_build_custom $BASE "$BASE_NONROOT_IMAGE_NAME" "" "Dockerfile-Base-Nonroot-Template"
-    docker_build_custom $DISTROLESS "$DISTROLESS_BASE_NONROOT_IMAGE_NAME" "$DISTROLESS_BASE_IMAGE_NAME" "Dockerfile-Distroless-Nonroot-Template"
-    docker_build_custom $DISTROLESS "$DISTROLESS_MINIMAL_NONROOT_IMAGE_NAME" "$DISTROLESS_MINIMAL_IMAGE_NAME" "Dockerfile-Distroless-Nonroot-Template"
-    docker_build_custom $DISTROLESS "$DISTROLESS_DEBUG_NONROOT_IMAGE_NAME" "$DISTROLESS_DEBUG_IMAGE_NAME" "Dockerfile-Distroless-Nonroot-Template"
+    docker_build_custom "$BASE" "$BASE_NONROOT_IMAGE_NAME" "" "Dockerfile-Base-Nonroot-Template"
+    docker_build_custom "$DISTROLESS" "$DISTROLESS_BASE_NONROOT_IMAGE_NAME" "$DISTROLESS_BASE_IMAGE_NAME" "Dockerfile-Distroless-Nonroot-Template"
+    docker_build_custom "$DISTROLESS" "$DISTROLESS_MINIMAL_NONROOT_IMAGE_NAME" "$DISTROLESS_MINIMAL_IMAGE_NAME" "Dockerfile-Distroless-Nonroot-Template"
+    docker_build_custom "$DISTROLESS" "$DISTROLESS_DEBUG_NONROOT_IMAGE_NAME" "$DISTROLESS_DEBUG_IMAGE_NAME" "Dockerfile-Distroless-Nonroot-Template"
 
     docker_build_marinara
 }


### PR DESCRIPTION
<!-- dd-meta {"pullId":"2f8a8d66-1203-4163-ace9-e97651ee3b93","source":"chat","resourceId":"0bf8b931-3bce-4147-b954-16c01a3cfcde","workflowId":"60df81a2-198c-4669-90ad-b48967ff7c7c","codeChangeId":"60df81a2-198c-4669-90ad-b48967ff7c7c","sourceType":"code_security_sast"} -->
###### Merge Checklist  <!-- REQUIRED -->

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/cd09a5677374818ef388571d98ca6690?panel_event_id=AwAAAZ_hs3-oROgf8QAAABhBWl9oczMtb0FBQ0tnLV9qMUtiSGN1NUUAAAAkMTE5ZmUxYjYtMGQ4MC00OGY0LTgxNmUtNTYwZjMwMGU0MTFkAAAEGw&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22Y2QwOWE1Njc3Mzc0ODE4ZWYzODg1NzFkOThjYTY2OTB-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Quote the base container image-type arguments in `.pipelines/containerSourceData/scripts/BuildBaseContainers.sh` so Bash passes each value as a single argument and cannot apply word splitting or glob expansion. This addresses the SAST finding for `bash-security/double-quote-variable-expansions` while preserving the existing container build flow.

###### Change Log  <!-- REQUIRED -->
- Quote `$BASE` and `$DISTROLESS` when passing image types to `docker_build` and `docker_build_custom`.
- Keep all existing image names, tarball paths, Dockerfile templates, and build ordering unchanged.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Test Methodology
- `bash -n .pipelines/containerSourceData/scripts/BuildBaseContainers.sh`
- `git diff --check`
- `shellcheck` was not installed in the execution environment.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/0bf8b931-3bce-4147-b954-16c01a3cfcde)

Comment @datadog to request changes