### PR TITLE
Quote xdg-utils helper variables

### DIFF
--- a/SPECS-EXTENDED/xdg-utils/xdg-utils-git_checkout.sh
+++ b/SPECS-EXTENDED/xdg-utils/xdg-utils-git_checkout.sh
@@ -7,11 +7,11 @@ DATE=$(date +%Y%m%d)git
 
 set -x
 
-rm -rf $MODULE
+rm -rf -- "$MODULE"
 
-git clone git://anongit.freedesktop.org/git/xdg/xdg-utils $MODULE/
-pushd $MODULE
-git archive master --format tar --prefix=${MODULE}-${VERSION}/ | gzip -9 > ../${MODULE}-${VERSION}-${DATE}.tar.gz
+git clone git://anongit.freedesktop.org/git/xdg/xdg-utils "$MODULE/"
+pushd "$MODULE"
+git archive master --format tar --prefix="${MODULE}-${VERSION}/" | gzip -9 > "../${MODULE}-${VERSION}-${DATE}.tar.gz"
 popd
 
-rm -rf $MODULE 
+rm -rf -- "$MODULE"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"46cfe1cd-c23c-44b3-a04f-e83d1aaa73ca","source":"chat","resourceId":"2e2dd744-66a6-4bf1-b0d7-f4db4e8436dc","workflowId":"0eb7596d-8733-4cfd-b4eb-3b5a9ec69156","codeChangeId":"0eb7596d-8733-4cfd-b4eb-3b5a9ec69156","sourceType":"code_security_sast"} -->
###### Motivation

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/61c28a176f94bcf2d58a03a1dac0daf4?panel_event_id=AwAAAZ_htFA-pdfBhAAAABhBWl9odEZBLUFBRGYyRVlnd0ptcWQ1c0EAAAAkMTE5ZmUxYjYtMGQ4MC00OGY0LTgxNmUtNTYwZjMwMGU0MTFkAAAEBg&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22NjFjMjhhMTc2Zjk0YmNmMmQ1OGEwM2ExZGFjMGRhZjR-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

The SAST finding bash-security/double-quote-variable-expansions flagged SPECS-EXTENDED/xdg-utils/xdg-utils-git_checkout.sh because unquoted shell variables can be split on whitespace or expanded as globs before being passed to commands. Even though the current values are static, quoting keeps the helper robust if those values change later.

###### Changes
- Quote MODULE, VERSION, and DATE expansions in SPECS-EXTENDED/xdg-utils/xdg-utils-git_checkout.sh command arguments and redirection paths.
- Add -- to rm invocations so the module name cannot be interpreted as an option.

###### Testing
- bash -n SPECS-EXTENDED/xdg-utils/xdg-utils-git_checkout.sh
- git diff --check
- shellcheck SPECS-EXTENDED/xdg-utils/xdg-utils-git_checkout.sh could not be run because shellcheck is not installed in this environment.

###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add @microsoft/cbl-mariner-multi-package-reviewers team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Quotes shell variable expansions in the xdg-utils git checkout helper to prevent word splitting and glob expansion in command arguments and generated archive paths.

###### Change Log  <!-- REQUIRED -->
- Updated SPECS-EXTENDED/xdg-utils/xdg-utils-git_checkout.sh to quote variable expansions used by rm, git clone, pushd, git archive, and the archive output path.
- Added -- to rm calls for option-safe cleanup.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Test Methodology
- bash -n SPECS-EXTENDED/xdg-utils/xdg-utils-git_checkout.sh
- git diff --check
- shellcheck SPECS-EXTENDED/xdg-utils/xdg-utils-git_checkout.sh could not be run because shellcheck is not installed in this environment.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/2e2dd744-66a6-4bf1-b0d7-f4db4e8436dc)

Comment @datadog to request changes