### PR TITLE
Quote container image type args

### DIFF
--- a/.pipelines/containerSourceData/scripts/BuildBaseContainers.sh
+++ b/.pipelines/containerSourceData/scripts/BuildBaseContainers.sh
@@ -345,15 +345,15 @@ function save_container_image {
 function build_images {
     echo "+++ Build images"
 
-    docker_build $BASE "$BASE_IMAGE_NAME" "$BASE_TARBALL" "Dockerfile-Base-Template"
-    docker_build $DISTROLESS "$DISTROLESS_BASE_IMAGE_NAME" "$DISTROLESS_BASE_TARBALL" "Dockerfile-Distroless-Template"
-    docker_build $DISTROLESS "$DISTROLESS_MINIMAL_IMAGE_NAME" "$DISTROLESS_MINIMAL_TARBALL" "Dockerfile-Distroless-Template"
-    docker_build $DISTROLESS "$DISTROLESS_DEBUG_IMAGE_NAME" "$DISTROLESS_DEBUG_TARBALL" "Dockerfile-Distroless-Template"
+    docker_build "$BASE" "$BASE_IMAGE_NAME" "$BASE_TARBALL" "Dockerfile-Base-Template"
+    docker_build "$DISTROLESS" "$DISTROLESS_BASE_IMAGE_NAME" "$DISTROLESS_BASE_TARBALL" "Dockerfile-Distroless-Template"
+    docker_build "$DISTROLESS" "$DISTROLESS_MINIMAL_IMAGE_NAME" "$DISTROLESS_MINIMAL_TARBALL" "Dockerfile-Distroless-Template"
+    docker_build "$DISTROLESS" "$DISTROLESS_DEBUG_IMAGE_NAME" "$DISTROLESS_DEBUG_TARBALL" "Dockerfile-Distroless-Template"
 
-    docker_build_custom $BASE "$BASE_NONROOT_IMAGE_NAME" "" "Dockerfile-Base-Nonroot-Template"
-    docker_build_custom $DISTROLESS "$DISTROLESS_BASE_NONROOT_IMAGE_NAME" "$DISTROLESS_BASE_IMAGE_NAME" "Dockerfile-Distroless-Nonroot-Template"
-    docker_build_custom $DISTROLESS "$DISTROLESS_MINIMAL_NONROOT_IMAGE_NAME" "$DISTROLESS_MINIMAL_IMAGE_NAME" "Dockerfile-Distroless-Nonroot-Template"
-    docker_build_custom $DISTROLESS "$DISTROLESS_DEBUG_NONROOT_IMAGE_NAME" "$DISTROLESS_DEBUG_IMAGE_NAME" "Dockerfile-Distroless-Nonroot-Template"
+    docker_build_custom "$BASE" "$BASE_NONROOT_IMAGE_NAME" "" "Dockerfile-Base-Nonroot-Template"
+    docker_build_custom "$DISTROLESS" "$DISTROLESS_BASE_NONROOT_IMAGE_NAME" "$DISTROLESS_BASE_IMAGE_NAME" "Dockerfile-Distroless-Nonroot-Template"
+    docker_build_custom "$DISTROLESS" "$DISTROLESS_MINIMAL_NONROOT_IMAGE_NAME" "$DISTROLESS_MINIMAL_IMAGE_NAME" "Dockerfile-Distroless-Nonroot-Template"
+    docker_build_custom "$DISTROLESS" "$DISTROLESS_DEBUG_NONROOT_IMAGE_NAME" "$DISTROLESS_DEBUG_IMAGE_NAME" "Dockerfile-Distroless-Nonroot-Template"
 
     docker_build_marinara
 }


### PR DESCRIPTION
<!-- dd-meta {"pullId":"a4fdb0d3-8981-4f80-bf19-fd2073405e71","source":"chat","resourceId":"f6772cf2-fb3e-48fa-b117-4200150bbe94","workflowId":"468e509e-bdfa-41c2-aadb-6b95e0ac4975","codeChangeId":"468e509e-bdfa-41c2-aadb-6b95e0ac4975","sourceType":"code_security_sast"} -->
###### Summary <!-- REQUIRED -->

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/cd09a5677374818ef388571d98ca6690?panel_event_id=AwAAAZ_hs3-oROgf8QAAABhBWl9oczMtb0FBQ0tnLV9qMUtiSGN1NUUAAAAkMTE5ZmUxYjMtYTA2MS00ODUzLWI5ODItMzg1Njk5NTdkOTAwAAAAKA&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22Y2QwOWE1Njc3Mzc0ODE4ZWYzODg1NzFkOThjYTY2OTB-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

Quotes the image-type arguments passed to the base container build helpers so Bash does not perform word splitting or glob expansion before the helpers receive them. This addresses the SAST finding for .pipelines/containerSourceData/scripts/BuildBaseContainers.sh:354.

###### Change Log  <!-- REQUIRED -->
- Quote BASE and DISTROLESS arguments in docker_build calls.
- Quote BASE and DISTROLESS arguments in docker_build_custom calls, including the reported distroless nonroot build.

###### Test Methodology
- bash -n .pipelines/containerSourceData/scripts/BuildBaseContainers.sh
- rg -n 'docker_build(_custom)? \$' .pipelines/containerSourceData/scripts/BuildBaseContainers.sh
- git diff --check

###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/f6772cf2-fb3e-48fa-b117-4200150bbe94)

Comment @datadog to request changes