### PR TITLE
Quote RabbitMQ test script paths

### DIFF
--- a/SPECS/rabbitmq-server/executeRabbitMQTests.sh
+++ b/SPECS/rabbitmq-server/executeRabbitMQTests.sh
@@ -67,7 +67,7 @@ echo ""
 
 
 # Remove existing/old test directories
-rm -rf $BAZEL_DIR $MANDOC_DIR $DAEMONIZE_DIR
+rm -rf "$BAZEL_DIR" "$MANDOC_DIR" "$DAEMONIZE_DIR"
 
 # Required dependencies are installed
 dnf install msopenjdk-11 wget git build-essential python3 zip unzip
@@ -78,18 +78,18 @@ wget https://mandoc.bsd.lv/snapshots/mandoc-1.14.6.tar.gz
 git clone http://github.com/bmc/daemonize.git
 
 # Install bazel 6.0.0
-mkdir $BAZEL_DIR
-mv bazel-6.0.0-dist.zip $BAZEL_DIR/bazel-6.0.0-dist.zip
-pushd $BAZEL_DIR
+mkdir "$BAZEL_DIR"
+mv bazel-6.0.0-dist.zip "$BAZEL_DIR/bazel-6.0.0-dist.zip"
+pushd "$BAZEL_DIR"
 unzip bazel-6.0.0-dist.zip
 env EXTRA_BAZEL_ARGS="--tool_java_runtime_version=local_jdk" bash ./compile.sh
-cp output/bazel $BAZEL_INSTALL_DIR/bazel
+cp output/bazel "$BAZEL_INSTALL_DIR/bazel"
 popd
 
 # Install mandoc 1.14.6
-mkdir $MANDOC_DIR
-mv mandoc-1.14.6.tar.gz $MANDOC_DIR/mandoc-1.14.6.tar.gz
-pushd $MANDOC_DIR
+mkdir "$MANDOC_DIR"
+mv mandoc-1.14.6.tar.gz "$MANDOC_DIR/mandoc-1.14.6.tar.gz"
+pushd "$MANDOC_DIR"
 tar -zxvf mandoc-1.14.6.tar.gz
 cd mandoc-1.14.6
 make
@@ -97,7 +97,7 @@ make install
 popd
 
 # Install daemonize 1.7.8
-pushd $DAEMONIZE_DIR
+pushd "$DAEMONIZE_DIR"
 sh configure
 make
 make install
@@ -105,18 +105,18 @@ export PATH="$PATH:/usr/local/sbin"
 popd
 
 # Make and install rabbitmq
-pushd $RABBIT_MQ_DIR
+pushd "$RABBIT_MQ_DIR"
 make distclean
 make
 make install
 popd
 
 # Run tests using bazel
-pushd $RABBIT_MQ_DIR
+pushd "$RABBIT_MQ_DIR"
 bazel clean
 bazel test //... --test_env="LC_ALL=en_US.UTF-8"
 popd
 
 # Restore PATH to original state
 export PATH="$EXISTING_USER_PATH"
-rm $BAZEL_INSTALL_DIR/bazel
+rm "$BAZEL_INSTALL_DIR/bazel"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"f2db2796-0e92-4854-9e64-3c2abcf693e1","source":"chat","resourceId":"e369a9fd-a48b-49e2-93a5-e0f060607b64","workflowId":"8e87242d-41a3-443b-ac5f-2e28171683ab","codeChangeId":"8e87242d-41a3-443b-ac5f-2e28171683ab","sourceType":"code_security_sast"} -->
###### Motivation

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/00bbf3741b4fdabfc8fd4dcf8bb4ba80?panel_event_id=AwAAAZ_hsnYJmzd2QwAAABhBWl9oc25ZSkFBQmJYZlFpNG5HcV9LN2wAAAAkMTE5ZmUxYjMtMjFlMi00ODdiLWIxYTItZmU3Yjc5NmIwMDNjAAAETw&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22MDBiYmYzNzQxYjRmZGFiZmM4ZmQ0ZGNmOGJiNGJhODB-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

The SAST finding reported an unquoted RABBIT_MQ_DIR expansion in SPECS/rabbitmq-server/executeRabbitMQTests.sh. PARENT_DIR is user configured, so paths containing whitespace or glob characters could be split or expanded by the shell before pushd receives them.

###### Changes
- Quote path variable expansions used by rm, mkdir, mv, pushd, cp, and final cleanup in SPECS/rabbitmq-server/executeRabbitMQTests.sh.
- Quote both RabbitMQ pushd invocations so the make/install and Bazel test phases use the exact configured RabbitMQ directory.

###### Testing
- bash -n SPECS/rabbitmq-server/executeRabbitMQTests.sh
- git diff --check

###### Merge Checklist
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add @microsoft/cbl-mariner-multi-package-reviewers team as reviewer (Eg. golang has 2 versions 1.18, 1.21+)
- [x] Ready to merge

---

###### Summary
Quotes user-configured path expansions in the RabbitMQ test execution helper so shell commands receive directory paths as single arguments.

###### Change Log
- Quote RabbitMQ, Bazel, mandoc, daemonize, and Bazel install path expansions in shell command arguments.
- Preserve existing test script behavior while preventing shell word splitting and glob expansion on configured paths.

###### Does this affect the toolchain?
**NO**

###### Test Methodology
- bash -n SPECS/rabbitmq-server/executeRabbitMQTests.sh
- git diff --check

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/e369a9fd-a48b-49e2-93a5-e0f060607b64)

Comment @datadog to request changes