### PR TITLE
Quote toolchain setup paths

### DIFF
--- a/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
+++ b/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
@@ -22,7 +22,7 @@ MARINER_TOOLCHAIN_MANIFESTS_FILE=${12}
 # =====================================================
 BLDTRACKER=${13}
 TIMESTAMP_FILE_PATH=${14}
-source $(dirname  $0)/../timestamp.sh
+source "$(dirname "$0")/../timestamp.sh"
 # =====================================================
 
 begin_timestamp
@@ -68,7 +68,7 @@ fi
 # The build/toolchain/populated_toolchain folder might exist, but not have the unpacked
 # chroot environment inside it. So, we need to check if some expected directory exists
 # within $LFS.
-pushd $MARINER_BUILD_DIR/toolchain
+pushd "$MARINER_BUILD_DIR/toolchain"
 if [[ ! -d "$LFS/usr" ]]
 then
     echo "$LFS not populated with chroot environment yet, unpacking tarball"
@@ -76,15 +76,15 @@ then
 fi
 popd
 
-mkdir -pv $FINISHED_RPM_DIR
-mkdir -pv $CHROOT_SPECS_DIR
-mkdir -pv $CHROOT_SRPMS_DIR
-mkdir -pv $CHROOT_SOURCES_DIR
-mkdir -pv $CHROOT_INSTALL_RPM_DIR
-mkdir -pv $TOOLCHAIN_LOGS
-mkdir -pv $CHROOT_RPMS_DIR
-mkdir -pv $CHROOT_RPMS_DIR_ARCH
-mkdir -pv $CHROOT_RPMS_DIR_NOARCH
+mkdir -pv "$FINISHED_RPM_DIR"
+mkdir -pv "$CHROOT_SPECS_DIR"
+mkdir -pv "$CHROOT_SRPMS_DIR"
+mkdir -pv "$CHROOT_SOURCES_DIR"
+mkdir -pv "$CHROOT_INSTALL_RPM_DIR"
+mkdir -pv "$TOOLCHAIN_LOGS"
+mkdir -pv "$CHROOT_RPMS_DIR"
+mkdir -pv "$CHROOT_RPMS_DIR_ARCH"
+mkdir -pv "$CHROOT_RPMS_DIR_NOARCH"
 
 TEMP_DIR=$(mktemp -d -t)
 TEMP_BUILT_RPMS_LIST="$(mktemp --tmpdir="$TEMP_DIR")"
@@ -102,10 +102,10 @@ function clean_up {
 trap clean_up EXIT
 
 # Remove artifacts from previous toolchain builds
-sudo rm -f $TOOLCHAIN_BUILD_LIST
-sudo rm -f $TOOLCHAIN_FAILURES
-sudo rm -rf $CHROOT_BUILDROOT_DIR
-touch $TOOLCHAIN_FAILURES
+sudo rm -f "$TOOLCHAIN_BUILD_LIST"
+sudo rm -f "$TOOLCHAIN_FAILURES"
+sudo rm -rf "$CHROOT_BUILDROOT_DIR"
+touch "$TOOLCHAIN_FAILURES"
 
 stop_record_timestamp "prep_files"
 start_record_timestamp "hydrate"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"ac354adb-f458-4c11-b4df-0c8923c6549a","source":"chat","resourceId":"765674c1-ff84-4e42-bd89-bacb0e9710a4","workflowId":"676dd14f-6d05-43be-bc55-baee7e86f05b","codeChangeId":"676dd14f-6d05-43be-bc55-baee7e86f05b","sourceType":"code_security_sast"} -->
###### Motivation

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/cb20004910842dc16a480e3f23a72665?panel_event_id=AwAAAZ_hsULpT190HwAAABhBWl9oc1VMcEFBQmE5LVhJTWUtcGZsdEUAAAAkMTE5ZmUxYjMtMjFlMi00ODdiLWIxYTItZmU3Yjc5NmIwMDNjAAAEZw&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22Y2IyMDAwNDkxMDg0MmRjMTZhNDgwZTNmMjNhNzI2NjV-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

Fixes a high-severity SAST finding in toolkit/scripts/toolchain/build_official_toolchain_rpms.sh where path-derived shell variables were expanded unquoted during toolchain setup. The affected CHROOT_INSTALL_RPM_DIR value is derived from MARINER_BUILD_DIR, so spaces or glob metacharacters in the build path could be split or expanded by the shell.

###### Changes
- Quote the timestamp helper path resolution.
- Quote toolchain setup directory paths, including CHROOT_INSTALL_RPM_DIR.
- Quote cleanup file and directory paths in the same setup block.

###### Testing
- bash -n toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
- git diff --check

###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add @microsoft/cbl-mariner-multi-package-reviewers team as reviewer
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Quotes shell path expansions in the toolchain RPM build setup to address the SAST word-splitting and glob-expansion finding.

###### Change Log  <!-- REQUIRED -->
- Quote CHROOT_INSTALL_RPM_DIR and neighboring setup directory variables when passed to mkdir.
- Quote the script-relative timestamp include path and build-directory pushd path.
- Quote cleanup paths passed to rm and touch.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**YES**

###### Test Methodology
- bash -n toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
- git diff --check

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/765674c1-ff84-4e42-bd89-bacb0e9710a4)

Comment @datadog to request changes