### PR TITLE
Quote container build resource paths

### DIFF
--- a/toolkit/scripts/containerized-build/create_container_build.sh
+++ b/toolkit/scripts/containerized-build/create_container_build.sh
@@ -198,12 +198,12 @@ for mount in $mounts $extra_mounts; do
 done
 
 # Copy resources into container
-cp resources/welcome.txt $tmp_dir
-sed -i "s~<REPO_PATH>~${repo_path}~" $tmp_dir/welcome.txt
-sed -i "s~<REPO_BRANCH>~${repo_branch}~" $tmp_dir/welcome.txt
-sed -i "s~<AARCH>~$(uname -m)~" $tmp_dir/welcome.txt
-cp resources/setup_functions.sh $tmp_dir/setup_functions.sh
-sed -i "s~<TOPDIR>~${topdir}~" $tmp_dir/setup_functions.sh
+cp resources/welcome.txt "${tmp_dir}"
+sed -i "s~<REPO_PATH>~${repo_path}~" "${tmp_dir}/welcome.txt"
+sed -i "s~<REPO_BRANCH>~${repo_branch}~" "${tmp_dir}/welcome.txt"
+sed -i "s~<AARCH>~$(uname -m)~" "${tmp_dir}/welcome.txt"
+cp resources/setup_functions.sh "${tmp_dir}/setup_functions.sh"
+sed -i "s~<TOPDIR>~${topdir}~" "${tmp_dir}/setup_functions.sh"
 
 # ============ Build the image ============
 dockerfile="${script_dir}/resources/mariner.Dockerfile"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"2464a670-8051-4075-a4e4-f376fbb3f164","source":"chat","resourceId":"8ffefeec-6538-4818-8f2e-63e1e120c5cb","workflowId":"9b169fb8-32da-48c2-92b0-5fba16fdec74","codeChangeId":"9b169fb8-32da-48c2-92b0-5fba16fdec74","sourceType":"code_security_sast"} -->
###### Summary <!-- REQUIRED -->

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/2a218fca2b6fa2f27e9c85ac43ae71e6?panel_event_id=AwAAAZ_hssfZAUNrdwAAABhBWl9oc3NmWkFBQUNQbzZOcVprNTBndzgAAAAkMTE5ZmUxYjMtMjFlMi00ODdiLWIxYTItZmU3Yjc5NmIwMDNjAAAERw&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22MmEyMThmY2EyYjZmYTJmMjdlOWM4NWFjNDNhZTcxZTZ-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

Quote containerized build resource path arguments so BUILD_DIR-derived tmp_dir values are passed to cp and sed as a single path. This fixes the SAST finding bash-security/double-quote-variable-expansions in toolkit/scripts/containerized-build/create_container_build.sh by preventing word splitting and glob expansion during resource setup.

###### Change Log  <!-- REQUIRED -->
- Quote tmp_dir path arguments when copying welcome.txt and setup_functions.sh into the temporary build directory.
- Quote tmp_dir path arguments used by sed when replacing placeholders in copied resource files.

###### Test Methodology
- bash -n toolkit/scripts/containerized-build/create_container_build.sh

###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/8ffefeec-6538-4818-8f2e-63e1e120c5cb)

Comment @datadog to request changes