### PR TITLE
Quote prometheus-adapter shell vars

### DIFF
--- a/SPECS/prometheus-adapter/generate_source_tarball.sh
+++ b/SPECS/prometheus-adapter/generate_source_tarball.sh
@@ -23,7 +23,7 @@ PARAMS=""
 while (( "$#" )); do
     case "$1" in
         --srcTarball)
-        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+        if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
             SRC_TARBALL=$2
             shift 2
         else
@@ -32,7 +32,7 @@ while (( "$#" )); do
         fi
         ;;
         --outFolder)
-        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+        if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
             OUT_FOLDER=$2
             shift 2
         else
@@ -41,7 +41,7 @@ while (( "$#" )); do
         fi
         ;;
         --pkgVersion)
-        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+        if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
             PKG_VERSION=$2
             shift 2
         else
@@ -73,7 +73,7 @@ echo "-- create temp folder"
 TEMPDIR=$(mktemp -d)
 function cleanup {
     echo "+++ cleanup -> remove $TEMPDIR"
-    rm -rf $TEMPDIR
+    rm -rf "$TEMPDIR"
 }
 trap cleanup EXIT
 
@@ -82,7 +82,7 @@ ADAPTER_URL="https://github.com/kubernetes-sigs/prometheus-adapter/archive/refs/
 
 cd "$TEMPDIR"
 # sudo chown -R "$USER": .
-wget -c $ADAPTER_URL -O "prometheus-adapter-$PKG_VERSION.tar.gz"
+wget -c "$ADAPTER_URL" -O "prometheus-adapter-$PKG_VERSION.tar.gz"
 tar -xzf "prometheus-adapter-$PKG_VERSION.tar.gz"
 cd "prometheus-adapter-$PKG_VERSION"
 go mod vendor


### PR DESCRIPTION
<!-- dd-meta {"pullId":"a0e36290-7fdc-406c-815c-c11ed9fec3c4","source":"chat","resourceId":"a21dd992-2afe-4316-b1f3-4f70977c6251","workflowId":"60f8627b-78ca-4e1e-a77f-ba174b2ff521","codeChangeId":"60f8627b-78ca-4e1e-a77f-ba174b2ff521","sourceType":"code_security_sast"} -->
###### Motivation/Summary

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/9c94589115ec1eaf776de045a4eb0b50?panel_event_id=AwAAAZ_hswKjvreKvwAAABhBWl9oc3dLakFBQTVtNGI2SHhBM3R2RGcAAAAkMTE5ZmUxYjMtMjFlMi00ODdiLWIxYTItZmU3Yjc5NmIwMDNjAAAEQQ&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22OWM5NDU4OTExNWVjMWVhZjc3NmRlMDQ1YTRlYjBiNTB-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

Double quote shell variable expansions in SPECS/prometheus-adapter/generate_source_tarball.sh to prevent word splitting and glob expansion when temporary paths, URLs, or option values contain shell metacharacters.

###### Changes
- Quote the temporary directory used by the cleanup rm command.
- Quote URL expansion passed to wget.
- Quote argument prefix checks for src tarball, output folder, and package version options.

###### Testing/Validation
- bash -n SPECS/prometheus-adapter/generate_source_tarball.sh
- git diff --check
- shellcheck is not installed in this workspace, so it could not be run.

###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Quotes shell variable expansions in the prometheus-adapter source tarball helper to address a SAST finding for word splitting and glob expansion.

###### Change Log  <!-- REQUIRED -->
- Quote the cleanup `rm -rf` temporary directory argument.
- Quote the `wget` URL argument.
- Quote option-prefix substring checks in argument parsing.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Test Methodology
- bash -n SPECS/prometheus-adapter/generate_source_tarball.sh
- git diff --check

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/a21dd992-2afe-4316-b1f3-4f70977c6251)

Comment @datadog to request changes