### PR TITLE
Quote kdump bond slave expansion

### DIFF
--- a/SPECS/kexec-tools/dracut-module-setup.sh
+++ b/SPECS/kexec-tools/dracut-module-setup.sh
@@ -245,7 +245,7 @@ kdump_setup_bond() {
         echo -n " ifname=$_kdumpdev:$_mac" >> ${initdir}/etc/cmdline.d/42bond.conf
         _slaves+="$_kdumpdev,"
     done
-    echo -n " bond=$_netdev:$(echo $_slaves | sed 's/,$//')" >> ${initdir}/etc/cmdline.d/42bond.conf
+    echo -n " bond=$_netdev:${_slaves%,}" >> "${initdir}/etc/cmdline.d/42bond.conf"
     # Get bond options specified in ifcfg
 
     source_ifcfg_file $_netdev


### PR DESCRIPTION
<!-- dd-meta {"pullId":"df515fcf-518d-4733-8e74-0bc8cc3ed84c","source":"chat","resourceId":"bf23ea88-466c-4084-b95f-eba5d3a19d47","workflowId":"b7643c36-7eea-4da8-952c-18734df740d9","codeChangeId":"b7643c36-7eea-4da8-952c-18734df740d9","sourceType":"code_security_sast"} -->
###### Summary <!-- REQUIRED -->

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/b5b3848f13576fc3b1435983d8c62a39?panel_event_id=AwAAAZ_hspqvvW6gIAAAABhBWl9oc3BxdkFBRDBMUGJCN1ZCVDkyMUwAAAAkMTE5ZmUxYjMtMjFlMi00ODdiLWIxYTItZmU3Yjc5NmIwMDNjAAAESg&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22YjViMzg0OGYxMzU3NmZjM2IxNDM1OTgzZDhjNjJhMzl-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

<!-- Quick explanation of the changes. -->
This fixes a high-severity SAST finding in SPECS/kexec-tools/dracut-module-setup.sh where the generated kdump bond slave list was expanded through an unquoted `echo` command substitution. The change prevents shell word splitting and glob expansion from altering the `bond=` dracut kernel argument.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Updated kdump_setup_bond to remove the trailing slave-list comma with shell parameter expansion instead of unquoted `echo $_slaves | sed ...`.
- Quoted the 42bond.conf redirect path on the changed line.
- Affected package: kexec-tools.
- CVEs fixed: none.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Ran `bash -n SPECS/kexec-tools/dracut-module-setup.sh`.
- Ran `git diff --check`.
- Verified `${_slaves%,}` preserves the previous trailing-comma removal behavior for a representative bond slave list.

---

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**NO**

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/bf23ea88-466c-4084-b95f-eba5d3a19d47)

Comment @datadog to request changes