### PR TITLE
Quote kernel update script paths

### DIFF
--- a/toolkit/scripts/update_kernel.sh
+++ b/toolkit/scripts/update_kernel.sh
@@ -41,20 +41,20 @@ function download {
 # $1 = path to spec
 # $2 = changelog entry text
 function create_new_changelog_entry {
-    CHANGELOG_LINE=$(grep -n %changelog $1 | tail -1 | cut -f1 -d:)
+    CHANGELOG_LINE=$(grep -n %changelog "$1" | tail -1 | cut -f1 -d:)
     NEW_CHANGELOG_LINE=$((CHANGELOG_LINE+1))
     NEW_CHANGELOG_DATE=$(date +"%a %b %d %Y")
     NEW_CHANGELOG_HEADER="* $NEW_CHANGELOG_DATE $USER_NAME <$USER_EMAIL> - $VERSION-1"
     NEW_CHANGELOG_ENTRY="- Update source to $VERSION"
     FULL_CHANGELOG_ENTRY="$NEW_CHANGELOG_HEADER\n$NEW_CHANGELOG_ENTRY\n"
-    sed -i "${NEW_CHANGELOG_LINE}i${FULL_CHANGELOG_ENTRY}" $1
+    sed -i "${NEW_CHANGELOG_LINE}i${FULL_CHANGELOG_ENTRY}" "$1"
 }
 
 # $1 = TARGET_SPEC
 function update_spec {
-    sed -i "s/Version:.*/Version:        $VERSION/" $1
-    sed -i "s/Release:.*/$NEW_RELEASE_NUMBER/" $1
-    create_new_changelog_entry $1
+    sed -i "s/Version:.*/Version:        $VERSION/" "$1"
+    sed -i "s/Release:.*/$NEW_RELEASE_NUMBER/" "$1"
+    create_new_changelog_entry "$1"
 }
 
 function find_old_version {
@@ -85,10 +85,10 @@ function update_configs {
 
 # $1 = TARGET_SIGNATUREJSON
 function update_signature {
-    SPEC_DIR=$(dirname $1)
-    SHA256="$(sha256sum $SPEC_DIR/$TARBALL_NAME | awk '{print $1;}')"
+    SPEC_DIR=$(dirname -- "$1")
+    SHA256="$(sha256sum "$SPEC_DIR/$TARBALL_NAME" | awk '{print $1;}')"
     FULL_SIGNATURE_ENTRY="  \"$TARBALL_NAME\": \"$SHA256\""
-    sed -i "s/  \"$FILE_SIGNATURE_PATTERN.*\": \".*\"/$FULL_SIGNATURE_ENTRY/" $1
+    sed -i "s/  \"$FILE_SIGNATURE_PATTERN.*\": \".*\"/$FULL_SIGNATURE_ENTRY/" "$1"
 }
 
 function update_toolchain_md5sum {
@@ -259,13 +259,13 @@ do
     TARGET_SPEC=$WORKSPACE/SPECS/$spec/$spec.spec
     TARGET_SIGNATUREJSON=$WORKSPACE/SPECS/$spec/$spec.signatures.json
     copy_local_tarball "$TARGET_SPEC"
-    update_spec $TARGET_SPEC
-    update_signature $TARGET_SIGNATUREJSON
+    update_spec "$TARGET_SPEC"
+    update_signature "$TARGET_SIGNATUREJSON"
 done
 for spec in $SIGNED_SPECS
 do
     TARGET_SPEC=$WORKSPACE/SPECS-SIGNED/$spec/$spec.spec
-    update_spec $TARGET_SPEC
+    update_spec "$TARGET_SPEC"
 done
 update_configs
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"f0383b8b-5fad-40ff-88f3-489453ead77d","source":"chat","resourceId":"1f55a965-97ce-4e34-81be-7c50251da43f","workflowId":"d545cc0c-45f9-4c36-b562-cd8a60b219cc","codeChangeId":"d545cc0c-45f9-4c36-b562-cd8a60b219cc","sourceType":"code_security_sast"} -->
###### Summary <!-- REQUIRED -->

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/16e08eeb8102867604c5d31125d97134?panel_event_id=AwAAAZ_hqOiLYGPPGgAAABhBWl9ocU9pTEFBQWlEUFVzd0dfQmRJVXIAAAAkMDE5ZmUxYTktYTA0Ny00NTVlLThlMmUtNjgwZGQwMDgzYzIwAAAHPA&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22MTZlMDhlZWI4MTAyODY3NjA0YzVkMzExMjVkOTcxMzR-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

Quote path arguments in `toolkit/scripts/update_kernel.sh` so workspace-derived spec and signature paths are passed intact to shell commands. This addresses the SAST finding for unquoted variable expansion, where paths containing spaces or glob characters could be split or expanded before `grep`, `sed`, `dirname`, or checksum commands received them.

###### Change Log  <!-- REQUIRED -->
- Quote spec path parameters in `create_new_changelog_entry` and `update_spec`.
- Quote signature JSON and tarball path handling in `update_signature`.
- Quote `update_spec` and `update_signature` call sites for workspace-derived paths.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Associated issues  <!-- optional -->
- None

###### Links to CVEs  <!-- optional -->
- None

###### Test Methodology
- `bash -n toolkit/scripts/update_kernel.sh`
- Sourced helper functions before main and verified `update_spec` and `update_signature` against temporary paths containing spaces.

---

###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add @microsoft/cbl-mariner-multi-package-reviewers team as reviewer
- [x] Ready to merge

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/1f55a965-97ce-4e34-81be-7c50251da43f)

Comment @datadog to request changes