### PR TITLE
Quote kdump NEWROOT expansion

### DIFF
--- a/SPECS/kexec-tools/kdump-lib-initramfs.sh
+++ b/SPECS/kexec-tools/kdump-lib-initramfs.sh
@@ -199,7 +199,7 @@ dump_to_rootfs()
     echo "Kdump: waiting for rootfs mount, will timeout after 90 seconds"
     systemctl start sysroot.mount
 
-    dump_fs $NEWROOT
+    dump_fs "$NEWROOT"
 }
 
 kdump_emergency_shell()

--- a/SPECS/kexec-tools/kexec-tools.signatures.json
+++ b/SPECS/kexec-tools/kexec-tools.signatures.json
@@ -16,7 +16,7 @@
   "fadump-howto.txt": "b9090c3e0e26b6124a0c8b0c79a7adf10637c9bbc34e0a59529e3f1b66c074f0",
   "kdump-dep-generator.sh": "f660e26df9c4843340093a294bcd41a68a71cea48314b5d1a3553bba5038bbbc",
   "kdump-in-cluster-environment.txt": "50784977e2c3a425ae00de4831f9fd4fb4a04574db1a72b9b28f7c0979a52564",
-  "kdump-lib-initramfs.sh": "28d2246007da7e6a29af5747485ff0547ac949b34e14c18e082bb9613a9a5057",
+  "kdump-lib-initramfs.sh": "a031d1318e81ea3636213b364aa37ea5efa76e797cdb25947da121967f0aee06",
   "kdump-lib.sh": "3d50507626d4a92b8448c7d6604923f6f460c4cb5c8b18977381a7d5e516dfba",
   "kdump-udev-throttler": "125d538a59172f779b40ea32fea1e4eb50d849f25eb2537a48328d4401136679",
   "kdump.conf": "1d7ed03fa55f52047a6be4047cb2bfea08ac025b82d52ace86d69e2ec06e2ce7",


### PR DESCRIPTION
<!-- dd-meta {"pullId":"ad911b6e-2c0f-41c7-ba4b-c66da9a36ed9","source":"chat","resourceId":"cd6d1fa2-98d7-4a29-85a2-c79da771976e","workflowId":"9e7bb074-2404-4cce-91a2-c8306b1ad2d7","codeChangeId":"9e7bb074-2404-4cce-91a2-c8306b1ad2d7","sourceType":"code_security_sast"} -->
###### Summary <!-- REQUIRED -->

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/bb9dfef702bf0a90638d4f36170f4f0d?panel_event_id=AwAAAZ_hpWJWuBZFigAAABhBWl9ocFdKV0FBQlpwTzJLb2dqZGRKS2UAAAAkMTE5ZmUxYTctYjAzNS00YWI0LWE1MjItZjYzMTQwOGRmZTg0AACwqQ&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22YmI5ZGZlZjcwMmJmMGE5MDYzOGQ0ZjM2MTcwZjRmMGR-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

Quote `NEWROOT` when `dump_to_rootfs` invokes `dump_fs` so the rootfs mount path is passed as a single argument without shell word splitting or glob expansion. This addresses the SAST finding in `SPECS/kexec-tools/kdump-lib-initramfs.sh`.

###### Change Log  <!-- REQUIRED -->
- Quote the `NEWROOT` expansion in `dump_to_rootfs` before passing it to `dump_fs`.
- Update `SPECS/kexec-tools/kexec-tools.signatures.json` with the new `kdump-lib-initramfs.sh` SHA256.

###### Test Methodology
- `bash -n SPECS/kexec-tools/kdump-lib-initramfs.sh`
- Verified the recorded `kdump-lib-initramfs.sh` signature matches `sha256sum`.
- `git diff --check -- SPECS/kexec-tools/kdump-lib-initramfs.sh SPECS/kexec-tools/kexec-tools.signatures.json`

###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/cd6d1fa2-98d7-4a29-85a2-c79da771976e)

Comment @datadog to request changes