### PR TITLE
Harden mailx tarball script paths

### DIFF
--- a/SPECS-EXTENDED/mailx/get-upstream-tarball.sh
+++ b/SPECS-EXTENDED/mailx/get-upstream-tarball.sh
@@ -13,8 +13,8 @@
 
 newdir=new-upstream-tarball
 
-mkdir $newdir
-cd $newdir
+mkdir "$newdir"
+cd "$newdir"
 
 # checkout cvs
 echo "== Just press Enter =="
@@ -25,10 +25,13 @@ cvs -d:pserver:anonymous@nail.cvs.sourceforge.net:/cvsroot/nail co nail
 rm -rf nail/CVS nail/catd/CVS
 
 # find version in nail/version.c file defined as: #define V "xxx"
-ver=$(sed -rn 's/#define\s+V\s+\"([0-9.]+)\"/\1/p' nail/version.c)
+ver=$(sed -rn 's/^#define[[:space:]]+V[[:space:]]+"([0-9]+([.][0-9]+)*)"[[:space:]]*$/\1/p' nail/version.c)
+if [ -z "$ver" ] || [ "$(printf '%s\n' "$ver" | wc -l)" -ne 1 ]; then
+    echo "Unable to determine mailx version from nail/version.c" >&2
+    exit 1
+fi
 
-mv nail mailx-$ver
-tar cJf mailx-$ver.tar.xz mailx-$ver
+mv nail "mailx-$ver"
+tar cJf "mailx-$ver.tar.xz" "mailx-$ver"
 
-rm -rf mailx-$ver
-
+rm -rf "mailx-$ver"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"dd890ad6-f8d9-4f6c-8918-613fb7b8cb73","source":"chat","resourceId":"a632ab29-5320-41e4-a316-45dd38ca8d75","workflowId":"084d9836-9b24-464d-aded-6f3f58319aa5","codeChangeId":"084d9836-9b24-464d-aded-6f3f58319aa5","sourceType":"code_security_sast"} -->
###### Summary

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/af717ad718e7b09e86d7e6ed9f1e7d06?panel_event_id=AwAAAZ_hpuUdLGWp1QAAABhBWl9ocHVVZEFBQ283dXhkb29WemE3blAAAAAkMTE5ZmUxYTctYjAzNS00YWI0LWE1MjItZjYzMTQwOGRmZTg0AACwiQ&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22YWY3MTdhZDcxOGU3YjA5ZTg2ZDdlNmVkOWYxZTdkMDZ-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

Tightens SPECS-EXTENDED/mailx/get-upstream-tarball.sh to address the high-severity SAST finding for unquoted shell variable expansions. The script reads version data from upstream CVS content before creating and deleting versioned paths, so those expansions should not be subject to word splitting or glob expansion.

###### Change Log
- Quote variable-derived directory and tarball path arguments.
- Parse the mailx version only from a complete `#define V "..."` line.
- Fail early if the version cannot be determined exactly once.

###### Test Methodology
- `sh -n SPECS-EXTENDED/mailx/get-upstream-tarball.sh`
- Parser checks for valid, trailing-text, commented, and duplicate version inputs
- `git diff --check`
- `shellcheck` was not available in the environment

###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add @microsoft/cbl-mariner-multi-package-reviewers team as reviewer
- [x] Ready to merge

---

###### Does this affect the toolchain?  <!-- REQUIRED -->
NO

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/a632ab29-5320-41e4-a316-45dd38ca8d75)

Comment @datadog to request changes