### PR TITLE
Quote container cleanup globs

### DIFF
--- a/toolkit/scripts/containerized-build/resources/setup_functions.sh
+++ b/toolkit/scripts/containerized-build/resources/setup_functions.sh
@@ -39,9 +39,9 @@ rpm() {
             fi
         done
     fi
-    rm -f $SPECS_DIR/*.spec
-    rm -f $SOURCES_DIR/*.spec
-    rm -f $SOURCES_DIR/*.signatures.json
+    rm -f "$SPECS_DIR"/*.spec
+    rm -f "$SOURCES_DIR"/*.spec
+    rm -f "$SOURCES_DIR"/*.signatures.json
 }
 
 # Installs srpm, pkg dependencies and builds pkg


### PR DESCRIPTION
<!-- dd-meta {"pullId":"1ea0e610-0ff7-46c7-bfa4-49ba5fd81b8c","source":"chat","resourceId":"e1c9b31d-a893-47fe-a2a0-a0acbc8ebcfb","workflowId":"72202b85-2dd9-4ff2-b482-60b6964dedf8","codeChangeId":"72202b85-2dd9-4ff2-b482-60b6964dedf8","sourceType":"code_security_sast"} -->
###### Motivation

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/ce04079db92a503f7e9608dd38e3dbac?panel_event_id=AwAAAZ_hpwv520q59QAAABhBWl9ocHd2NUFBQ2dEMFRubFVVdm1rU0MAAAAkMTE5ZmUxYTctYjAzNS00YWI0LWE1MjItZjYzMTQwOGRmZTg0AACwhQ&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22Y2UwNDA3OWRiOTJhNTAzZjdlOTYwOGRkMzhlM2RiYWN-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

The containerized build setup script cleaned extracted spec files using unquoted directory variables. If the generated paths ever contain whitespace or glob metacharacters, Bash can split or expand the directory value before `rm` runs, which can delete the wrong path or fail to clean the intended files.

###### Changes
- Quote the `SPECS_DIR` and `SOURCES_DIR` portions of the cleanup globs in toolkit/scripts/containerized-build/resources/setup_functions.sh.
- Keep the `*.spec` and `*.signatures.json` globs unquoted so the cleanup behavior remains unchanged.

###### Testing
- `bash -n <(sed 's~<TOPDIR>~/usr/src/mariner~' toolkit/scripts/containerized-build/resources/setup_functions.sh)`
- Targeted cleanup check with temporary `SPECS_DIR` and `SOURCES_DIR` paths containing spaces.
- `bash -n toolkit/scripts/containerized-build/create_container_build.sh`
- `git diff --check`

###### Merge Checklist
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add @microsoft/cbl-mariner-multi-package-reviewers team as reviewer
- [x] Ready to merge

---

###### Summary
Quotes the path portions of the cleanup globs in the containerized build setup script to prevent shell word splitting and unintended glob expansion during spec cleanup.

###### Change Log
- Quote `SPECS_DIR` when removing copied `*.spec` files.
- Quote `SOURCES_DIR` when removing copied `*.spec` files.
- Quote `SOURCES_DIR` when removing copied `*.signatures.json` files.

###### Does this affect the toolchain?
**NO**

###### Associated issues
- None

###### Links to CVEs
- None

###### Test Methodology
- Ran Bash syntax validation on the generated setup script after replacing `<TOPDIR>`.
- Ran a targeted cleanup check with temporary directories containing spaces to verify the quoted globs delete only the intended files.
- Ran Bash syntax validation on toolkit/scripts/containerized-build/create_container_build.sh.
- Ran `git diff --check`.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/e1c9b31d-a893-47fe-a2a0-a0acbc8ebcfb)

Comment @datadog to request changes