### PR TITLE
Quote kdump team config temp path

### DIFF
--- a/SPECS/kexec-tools/dracut-module-setup.sh
+++ b/SPECS/kexec-tools/dracut-module-setup.sh
@@ -257,6 +257,7 @@ kdump_setup_bond() {
 kdump_setup_team() {
     local _netdev=$1
     local _dev _mac _slaves _kdumpdev
+    local _team_conf="${initdir}/tmp/$$-$_netdev.conf"
     for _dev in `teamnl $_netdev ports | awk -F':' '{print $2}'`; do
         _mac=$(kdump_get_perm_addr $_dev)
         _kdumpdev=$(kdump_setup_ifname $_dev)
@@ -266,15 +267,15 @@ kdump_setup_team() {
     echo " team=$_netdev:$(echo $_slaves | sed -e 's/,$//')" >> ${initdir}/etc/cmdline.d/44team.conf
     #Buggy version teamdctl outputs to stderr!
     #Try to use the latest version of teamd.
-    teamdctl "$_netdev" config dump > ${initdir}/tmp/$$-$_netdev.conf
+    teamdctl "$_netdev" config dump > "$_team_conf"
     if [ $? -ne 0 ]
     then
         derror "teamdctl failed."
         exit 1
     fi
     inst_dir /etc/teamd
-    inst_simple ${initdir}/tmp/$$-$_netdev.conf "/etc/teamd/$_netdev.conf"
-    rm -f ${initdir}/tmp/$$-$_netdev.conf
+    inst_simple "$_team_conf" "/etc/teamd/$_netdev.conf"
+    rm -f "$_team_conf"
 }
 
 kdump_setup_vlan() {


### PR DESCRIPTION
<!-- dd-meta {"pullId":"92c31b8c-aac4-4a10-83cf-a0b92a3ab36c","source":"chat","resourceId":"84a177a5-0026-4e2a-97c6-ae9b405e512d","workflowId":"aa3ab1fd-cbd8-47ed-a7d5-22b72f610a92","codeChangeId":"aa3ab1fd-cbd8-47ed-a7d5-22b72f610a92","sourceType":"code_security_sast"} -->
###### Summary <!-- REQUIRED -->

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/f08035ab549e81810c4c6643ef1bb91f?panel_event_id=AwAAAZ_hqHUFEGcjZAAAABhBWl9ocUhVRkFBRDlmMkllUkIzWEFaZEsAAAAkMDE5ZmUxYTktYTA0Ny00NTVlLThlMmUtNjgwZGQwMDgzYzIwAAAHQg&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22ZjA4MDM1YWI1NDllODE4MTBjNGM2NjQzZWYxYmI5MWZ-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

Quote the kdump team temporary teamd config path before passing it to shell redirection, dracut's `inst_simple`, and cleanup. The SAST finding is a true positive because the path includes the runtime network device name, and leaving it unquoted allows shell glob expansion before the command receives the intended single path argument.

###### Change Log  <!-- REQUIRED -->
- Store the generated teamd temporary config path in a local variable in `SPECS/kexec-tools/dracut-module-setup.sh`.
- Double quote that path when writing the config, installing it into the initramfs, and removing the temporary file.

###### Test Methodology
- `bash -n SPECS/kexec-tools/dracut-module-setup.sh`
- `git diff --check`

---

###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Associated issues  <!-- optional -->
N/A

###### Links to CVEs  <!-- optional -->
N/A

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/84a177a5-0026-4e2a-97c6-ae9b405e512d)

Comment @datadog to request changes