### PR TITLE
Quote distroless USER_UID build arg

### DIFF
--- a/.pipelines/containerSourceData/scripts/BuildGoldenDistrolessContainer.sh
+++ b/.pipelines/containerSourceData/scripts/BuildGoldenDistrolessContainer.sh
@@ -37,7 +37,7 @@ function DockerBuild {
         --build-arg PACKAGES_TO_INSTALL="$packagesToInstall" \
         --build-arg PACKAGES_TO_HOLDBACK="$packagesToHoldback" \
         --build-arg USER="$user" \
-        --build-arg USER_UID=$userUid \
+        --build-arg USER_UID="$userUid" \
         --build-arg RPMS="$rpmsDir" \
         --build-arg LOCAL_REPO_FILE="$marinaraSrcDir/local.repo" \
         --no-cache


### PR DESCRIPTION
<!-- dd-meta {"pullId":"0d64321d-845a-4ce6-b3fd-fbbdc758af31","source":"chat","resourceId":"5661772d-9fef-43a2-8021-08ab459b23cb","workflowId":"cbf5df6b-40c8-44f7-8299-fccb0d3566ce","codeChangeId":"cbf5df6b-40c8-44f7-8299-fccb0d3566ce","sourceType":"code_security_sast"} -->
###### Summary

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/fa3485e9d55f381fe9aadebff2e66b17?panel_event_id=AwAAAZ_hqUorAAQUGgAAABhBWl9ocVVvckFBQkU0cEt3djR3OWRNaE8AAAAkMDE5ZmUxYTktYTA0Ny00NTVlLThlMmUtNjgwZGQwMDgzYzIwAAAHNw&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22ZmEzNDg1ZTlkNTVmMzgxZmU5YWFkZWJmZjJlNjZiMTd-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

Quote the `USER_UID` Docker build argument in `.pipelines/containerSourceData/scripts/BuildGoldenDistrolessContainer.sh` so Bash passes the UID as one argument and does not apply word splitting or glob expansion. This addresses the SAST finding for unquoted variable expansion in the distroless container build script.

###### Change Log
- Quoted the `userUid` expansion used to construct the `USER_UID` Docker build argument for distroless container builds.

###### Test Methodology
- `bash -n .pipelines/containerSourceData/scripts/BuildGoldenDistrolessContainer.sh`
- `git diff --check`
- `shellcheck` was not available in this environment.

###### Merge Checklist
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add microsoft/cbl-mariner-multi-package-reviewers team as reviewer
- [x] Ready to merge

---

###### Does this affect the toolchain?
**NO**

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/5661772d-9fef-43a2-8021-08ab459b23cb)

Comment @datadog to request changes