### PR TITLE
Quote repo path for git branch lookup

### DIFF
--- a/toolkit/scripts/containerized-build/create_container_build.sh
+++ b/toolkit/scripts/containerized-build/create_container_build.sh
@@ -128,7 +128,7 @@ cd "${script_dir}"  || { echo "ERROR: Could not change directory to ${script_dir
 # ==================== Setup ====================
 
 # Get Mariner GitHub branch at $repo_path
-repo_branch=$(git -C ${repo_path} rev-parse --abbrev-ref HEAD)
+repo_branch=$(git -C "${repo_path}" rev-parse --abbrev-ref HEAD)
 
 # Generate text based on mode (Use figlet to generate splash text once available on Mariner)
 if [[ "${mode}" == "build" ]]; then


### PR DESCRIPTION
<!-- dd-meta {"pullId":"1c295630-28b5-46ef-85b8-869d912f4668","source":"chat","resourceId":"28407327-a5e2-4e7a-bc6b-6bd3b7f37577","workflowId":"f15b6d24-da1a-4bd5-a10b-d0f0727651c3","codeChangeId":"f15b6d24-da1a-4bd5-a10b-d0f0727651c3","sourceType":"code_security_sast"} -->
###### Summary

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/a010861f67570535af2b03741a5982e9?panel_event_id=AwAAAZ_hqDzYG-ue2AAAABhBWl9ocUR6WUFBQk5DeHQwRENOalFfZ1IAAAAkMDE5ZmUxYTktYTA0Ny00NTVlLThlMmUtNjgwZGQwMDgzYzIwAAAHRw&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22YTAxMDg2MWY2NzU3MDUzNWFmMmIwMzc0MWE1OTgyZTl-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

The containerized build helper accepts a repository path from callers and then uses it in a `git -C` command. Quoting the path preserves it as a single argument so whitespace or glob characters cannot alter the command arguments during branch lookup.

###### Change Log
- Quote repo_path in toolkit/scripts/containerized-build/create_container_build.sh when calling `git -C`.

###### Test Methodology
- `bash -n toolkit/scripts/containerized-build/create_container_build.sh`
- `git diff --check`
- `shellcheck` was not available in this environment.

###### Merge Checklist
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add @microsoft/cbl-mariner-multi-package-reviewers team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Does this affect the toolchain?
**NO**

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/28407327-a5e2-4e7a-bc6b-6bd3b7f37577)

Comment @datadog to request changes