### PR TITLE
Quote xerces-j2 launcher variables

### DIFF
--- a/SPECS-EXTENDED/xerces-j2/xerces-j2-constants.sh
+++ b/SPECS-EXTENDED/xerces-j2/xerces-j2-constants.sh
@@ -12,9 +12,9 @@ MAIN_CLASS=org.apache.xerces.impl.Constants
 
 # Set parameters
 set_jvm
-export CLASSPATH=$(build-classpath xerces-j2)
-set_flags $BASE_FLAGS
-set_options $BASE_OPTIONS
+export CLASSPATH="$(build-classpath xerces-j2)"
+set_flags "${BASE_FLAGS:-}"
+set_options "${BASE_OPTIONS:-}"
 
 # Let's start
 run "$@"

--- a/SPECS-EXTENDED/xerces-j2/xerces-j2.signatures.json
+++ b/SPECS-EXTENDED/xerces-j2/xerces-j2.signatures.json
@@ -2,7 +2,7 @@
  "Signatures": {
   "Xerces-J-src.2.12.0.tar.gz": "c27b81e139ecfc219202bcad79e77529b082e9ed9797bc1a4c13e1bd8f8e31c9",
   "xerces-j2-constants.1": "f7489330cec3ee51c55d87ad7f38add648b04a2fff544e7e43a4bb1dde7e7c21",
-  "xerces-j2-constants.sh": "433dad71f6b6848027e6b79aecbdc02ea06e9e4671c664bb19cf9bcd19699abf",
+  "xerces-j2-constants.sh": "59788d2a50cf752ad681c1a718f0198be1515409748ae0ef97380000a2443b28",
   "xerces-j2-version.1": "49bfcc92965a0e2f7caf0ab231df43a328197222c79894911726ecd78032089e",
   "xerces-j2-version.sh": "0010deebc51ed019ec46b7041e946665a36e0ae679e06db3403ec6eed0260efe",
   "xercesImpl-2.12.0.pom": "138ebb33cce7080fd5cdb4fb90a0ee550173d7e8d41024da8c0d788b1460a1f3"

--- a/SPECS-EXTENDED/xerces-j2/xerces-j2.spec
+++ b/SPECS-EXTENDED/xerces-j2/xerces-j2.spec
@@ -22,7 +22,7 @@ Distribution:   Mariner
 %define __requires_exclude system.bundle
 Name:           xerces-j2
 Version:        2.12.0
-Release:        5%{?dist}
+Release:        6%{?dist}
 Summary:        Java XML parser
 License:        ASL 2.0 and Public Domain and W3C
 Group:          Development/Libraries/Java
@@ -173,6 +173,9 @@ ln -sf %{name}.jar %{_javadir}/jaxp_parser_impl.jar
 %{_datadir}/%{name}
 
 %changelog
+* Sat Aug 08 2026 Datadog Bits Dev <bits-dev@datadoghq.com> - 2.12.0-6
+- Quote variable expansions in the constants launcher script.
+
 * Thu Oct 14 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 2.12.0-5
 - Converting the 'Release' tag to the '[number].[distribution]' format.
 - License verified.


### PR DESCRIPTION
<!-- dd-meta {"pullId":"d20f38d7-3be2-4222-b815-a063a10e115f","source":"chat","resourceId":"ef64c79a-26ed-4011-ba17-e10cbb4f27eb","workflowId":"8483400a-21cb-4558-bafd-741b4976712f","codeChangeId":"8483400a-21cb-4558-bafd-741b4976712f","sourceType":"code_security_sast"} -->
###### Summary <!-- REQUIRED -->

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/ec98bbf678270874f48fa5ad54d8c34d?panel_event_id=AwAAAZ_hkOAHiaDEfwAAABhBWl9oa09BSEFBQm1SSU52ejJnQ3RQWEoAAAAkMTE5ZmUxOTAtZjdkMS00N2FiLWJjOGEtYWEyMDE4ODM2OGJiAAAAdg&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22ZWM5OGJiZjY3ODI3MDg3NGY0OGZhNWFkNTRkOGMzNGR-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

The xerces-j2 constants launcher forwarded `BASE_FLAGS` and `BASE_OPTIONS` without quoting, allowing shell word splitting and pathname expansion before the Java helper functions received those values. This quotes the launcher inputs so SAST finding `bash-security/double-quote-variable-expansions` is addressed in the packaged script.

###### Change Log  <!-- REQUIRED -->
- Quote the `build-classpath`, `BASE_FLAGS`, and `BASE_OPTIONS` expansions in `SPECS-EXTENDED/xerces-j2/xerces-j2-constants.sh`.
- Refresh the `xerces-j2-constants.sh` SHA-256 entry in `SPECS-EXTENDED/xerces-j2/xerces-j2.signatures.json`.
- Bump the `xerces-j2` RPM release and add a changelog entry for the packaged script change.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Test Methodology
- `sh -n SPECS-EXTENDED/xerces-j2/xerces-j2-constants.sh`
- `bash -n SPECS-EXTENDED/xerces-j2/xerces-j2-constants.sh`
- `jq -e . SPECS-EXTENDED/xerces-j2/xerces-j2.signatures.json >/dev/null`
- Verified the recorded `xerces-j2-constants.sh` signature matches `sha256sum`.
- `git diff --check`

###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/ef64c79a-26ed-4011-ba17-e10cbb4f27eb)

Comment @datadog to request changes