### PR TITLE
Quote moby-cli tarball paths

### DIFF
--- a/SPECS/moby-cli/generate_source_tarball.sh
+++ b/SPECS/moby-cli/generate_source_tarball.sh
@@ -23,8 +23,8 @@ PARAMS=""
 while (( "$#" )); do
     case "$1" in
         --srcTarball)
-        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
-            SRC_TARBALL=$2
+        if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
+            SRC_TARBALL="$2"
             shift 2
         else
             echo "Error: Argument for $1 is missing" >&2
@@ -32,8 +32,8 @@ while (( "$#" )); do
         fi
         ;;
         --outFolder)
-        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
-            OUT_FOLDER=$2
+        if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
+            OUT_FOLDER="$2"
             shift 2
         else
             echo "Error: Argument for $1 is missing" >&2
@@ -41,8 +41,8 @@ while (( "$#" )); do
         fi
         ;;
         --pkgVersion)
-        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
-            PKG_VERSION=$2
+        if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
+            PKG_VERSION="$2"
             shift 2
         else
             echo "Error: Argument for $1 is missing" >&2
@@ -50,8 +50,8 @@ while (( "$#" )); do
         fi
         ;;
         --vendorVersion)
-        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
-            VENDOR_VERSION=$2
+        if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
+            VENDOR_VERSION="$2"
             shift 2
         else
             echo "Error: Argument for $1 is missing" >&2
@@ -80,25 +80,25 @@ if [ -z "$PKG_VERSION" ]; then
 fi
 
 echo "-- create temp folder"
-tmpdir=$(mktemp -d)
+tmpdir="$(mktemp -d)"
 function cleanup {
     echo "+++ cleanup -> remove $tmpdir"
-    rm -rf $tmpdir
+    rm -rf "$tmpdir"
 }
 trap cleanup EXIT
 
 TARBALL_FOLDER="$tmpdir/tarballFolder"
-mkdir -p $TARBALL_FOLDER
-cp $SRC_TARBALL $tmpdir
+mkdir -p "$TARBALL_FOLDER"
+cp "$SRC_TARBALL" "$tmpdir"
 
-pushd $tmpdir > /dev/null
+pushd "$tmpdir" > /dev/null
 
 PKG_NAME="moby-cli"
 NAME_VER="$PKG_NAME-$PKG_VERSION"
 VENDOR_TARBALL="$OUT_FOLDER/$NAME_VER-govendor-v$VENDOR_VERSION.tar.gz"
 
 echo "Unpacking source tarball..."
-tar -xf $SRC_TARBALL
+tar -xf "$SRC_TARBALL"
 
 echo "Vendor go modules..."
 cd cli-"$PKG_VERSION"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"2a0fc1cd-c4bf-4fac-a08b-3bee7825875b","source":"chat","resourceId":"12c3143d-bb5c-4f31-9aa2-28e8cc6d3b63","workflowId":"4e31bc75-0dab-4d5b-8789-f75e65275976","codeChangeId":"4e31bc75-0dab-4d5b-8789-f75e65275976","sourceType":"code_security_sast"} -->
###### Summary <!-- REQUIRED -->

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/b74896140c900757771511c8bf9b482b?panel_event_id=AwAAAZ_hkOAIToMqcgAAABhBWl9oa09BSUFBQVp4ZnotUVYwYXhPaGMAAAAkMTE5ZmUxOTAtZjdkMS00N2FiLWJjOGEtYWEyMDE4ODM2OGJiAAAAdQ&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22Yjc0ODk2MTQwYzkwMDc1Nzc3MTUxMWM4YmY5YjQ4MmJ-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

Quote shell variable expansions in SPECS/moby-cli/generate_source_tarball.sh so the source tarball generator handles paths with spaces or glob characters instead of splitting them into multiple command arguments. This addresses the SAST finding for bash-security/double-quote-variable-expansions in the moby-cli source tarball helper.

###### Change Log  <!-- REQUIRED -->
- Quote CLI option values when storing script arguments.
- Quote substring checks used during option parsing.
- Quote temporary directory, source tarball, and output path expansions used by cleanup, copy, directory changes, and tar extraction.

###### Test Methodology
- bash -n SPECS/moby-cli/generate_source_tarball.sh
- Ran a local fixture with spaces in TMPDIR, --srcTarball, and --outFolder using stubbed go/vendor commands; verified the expected vendor tarball was produced.

---

###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/12c3143d-bb5c-4f31-9aa2-28e8cc6d3b63)

Comment @datadog to request changes