### PR TITLE
Quote reaper cache copy path

### DIFF
--- a/SPECS/reaper/reaper_build_caches.sh
+++ b/SPECS/reaper/reaper_build_caches.sh
@@ -158,6 +158,6 @@ createCacheTars
 
 mkdir "$HOME/reaper_caches"
 
-cp -a ${reaperCacheDir} "$HOME/reaper_caches"
+cp -a "${reaperCacheDir}" "$HOME/reaper_caches"
 
 echo "Copied cache tars to $HOME/reaper_caches/ .Exiting."


### PR DESCRIPTION
<!-- dd-meta {"pullId":"bbe1e6eb-42c3-4f31-808e-b253eb2fac21","source":"chat","resourceId":"6ffe9ae3-aef3-4a27-b2d4-2422904ffcaf","workflowId":"b8f332a3-0adc-48f2-bb33-313f24b053e8","codeChangeId":"b8f332a3-0adc-48f2-bb33-313f24b053e8","sourceType":"code_security_sast"} -->
###### Summary <!-- REQUIRED -->

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/184a59978d95156ddab3ce6bde0ad3a2?panel_event_id=AwAAAZ_hkOAHpLmbnQAAABhBWl9oa09BSEFBRFQ2VzNzOEFuV013ZHYAAAAkMTE5ZmUxOTAtZjdkMS00N2FiLWJjOGEtYWEyMDE4ODM2OGJiAAAAeA&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22MTg0YTU5OTc4ZDk1MTU2ZGRhYjNjZTZiZGUwYWQzYTJ-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

Quote the reaper build cache source path when copying generated caches so temp directories containing whitespace or glob characters are handled as a single path. This addresses the high-severity SAST finding for unquoted shell variable expansion in SPECS/reaper/reaper_build_caches.sh.

###### Change Log  <!-- REQUIRED -->
- Quote the `reaperCacheDir` expansion passed to `cp -a` in SPECS/reaper/reaper_build_caches.sh.

###### Test Methodology
- `bash -n SPECS/reaper/reaper_build_caches.sh`
- `git diff --check -- SPECS/reaper/reaper_build_caches.sh`
- Full cache generation was not run because the script installs packages and downloads build dependencies.

###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Associated issues  <!-- optional -->

###### Links to CVEs  <!-- optional -->

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/6ffe9ae3-aef3-4a27-b2d4-2422904ffcaf)

Comment @datadog to request changes