### PR TITLE
Quote toolchain SRPM path expansions

### DIFF
--- a/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
+++ b/toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
@@ -238,7 +238,7 @@ chroot_and_run_rpmbuild () {
         rpmbuild --nodeps --rebuild --clean     \
             $CHECK_SETTING                 \
             --define "with_check $CHECK_DEFINE_NUM" --define "dist $PARAM_DIST_TAG" --define "mariner_build_number $PARAM_BUILD_NUM" \
-            --define "mariner_release_version $PARAM_RELEASE_VER" $TOPDIR/SRPMS/$1 \
+            --define "mariner_release_version $PARAM_RELEASE_VER" "$TOPDIR/SRPMS/$1" \
             --define "mariner_module_ldflags -Wl,-dT,%{_topdir}/BUILD/module_info.ld" \
             || echo "$1" >> "$TOOLCHAIN_FAILURES"
 
@@ -252,13 +252,17 @@ build_rpm_in_chroot_no_install () {
     start_record_timestamp "build packages/build/$1"
     # $1 = spec name
 
-    specPath=$(find $SPECROOT -name "$1.spec" -print -quit)
-    specDir=$(dirname $specPath)
+    specPath=$(find "$SPECROOT" -name "$1.spec" -print -quit)
+    specDir=$(dirname "$specPath")
     rpmMacros=(-D "with_check $CHECK_DEFINE_NUM" -D "_sourcedir $specDir" -D "dist $PARAM_DIST_TAG")
-    builtRpms="$(rpmspec -q $specPath --builtrpms "${rpmMacros[@]}" --queryformat="%{nvra}.rpm\n")"
+    builtRpmsOutput="$(rpmspec -q "$specPath" --builtrpms "${rpmMacros[@]}" --queryformat="%{nvra}.rpm\n")"
+    builtRpms=()
+    if [[ -n "$builtRpmsOutput" ]]; then
+        mapfile -t builtRpms <<< "$builtRpmsOutput"
+    fi
 
     builtEarlier=false
-    if grep -qP "^$1\$" $TEMP_BUILT_SPECS_LIST; then
+    if grep -qP "^$1\$" "$TEMP_BUILT_SPECS_LIST"; then
         builtEarlier=true
     fi
 
@@ -274,31 +278,31 @@ build_rpm_in_chroot_no_install () {
     elif [ "$INCREMENTAL_TOOLCHAIN" = "y" ]; then
         # Find all the associated RPMs for the SRPM and check if they are in the chroot RPM directory.
         skipBuild=true
-        for rpm in $builtRpms; do
-            rpmPath=$(find $CHROOT_RPMS_DIR -name "$rpm" -print -quit)
+        for rpm in "${builtRpms[@]}"; do
+            rpmPath=$(find "$CHROOT_RPMS_DIR" -name "$rpm" -print -quit)
             if [ -z "$rpmPath" ]; then
                 echo "Did not find incremental toolchain rpm '$rpm' in '$CHROOT_RPMS_DIR', must rebuild."
                 skipBuild=false
                 break
             else
-                cp $rpmPath $FINISHED_RPM_DIR
+                cp "$rpmPath" "$FINISHED_RPM_DIR"
             fi
         done
     fi
 
     if ! $skipBuild; then
         echo only building RPM $1 within the chroot
-        srpmName=$(rpmspec -q $specPath --srpm "${rpmMacros[@]}" --queryformat %{NAME}-%{VERSION}-%{RELEASE}.src.rpm)
+        srpmName=$(rpmspec -q "$specPath" --srpm "${rpmMacros[@]}" --queryformat %{NAME}-%{VERSION}-%{RELEASE}.src.rpm)
         srpmPath=$MARINER_INPUT_SRPMS_DIR/$srpmName
-        cp $srpmPath $CHROOT_SRPMS_DIR
-        chroot_and_run_rpmbuild $srpmName 2>&1 | awk '{ print strftime("time=\"%Y-%m-%dT%T%Z\""), $0; fflush(); }' | tee $TOOLCHAIN_LOGS/$srpmName.log
-        copy_built_rpms $builtRpms
-        cp $srpmPath $MARINER_OUTPUT_SRPMS_DIR
-        echo "$1" >> $TEMP_BUILT_SPECS_LIST
-        echo NOT installing the package $srpmName
+        cp "$srpmPath" "$CHROOT_SRPMS_DIR"
+        chroot_and_run_rpmbuild "$srpmName" 2>&1 | awk '{ print strftime("time=\"%Y-%m-%dT%T%Z\""), $0; fflush(); }' | tee "$TOOLCHAIN_LOGS/$srpmName.log"
+        copy_built_rpms "${builtRpms[@]}"
+        cp "$srpmPath" "$MARINER_OUTPUT_SRPMS_DIR"
+        echo "$1" >> "$TEMP_BUILT_SPECS_LIST"
+        echo NOT installing the package "$srpmName"
     fi
 
-    echo "$1" >> $TOOLCHAIN_BUILD_LIST
+    echo "$1" >> "$TOOLCHAIN_BUILD_LIST"
     stop_record_timestamp "build packages/build/$1"
 }
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"e8b75c1c-3b13-4bb3-99f5-91f8e0b57387","source":"chat","resourceId":"42473bb9-21d9-45f0-893a-1d75ffcaebe2","workflowId":"9ad86ef4-b818-4eb0-a751-133919e8c6ff","codeChangeId":"9ad86ef4-b818-4eb0-a751-133919e8c6ff","sourceType":"code_security_sast"} -->
###### Summary

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/4cb5d6b0f2f387ea23f0feacef836041?panel_event_id=AwAAAZ_hkSRCQcOhuwAAABhBWl9oa1NSQ0FBQUtwSGRpUU0yRzlDNUIAAAAkMTE5ZmUxOTEtM2EzOC00OTA4LWJlODUtYThkMThhNWU4MjM5AAAAKA&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22NGNiNWQ2YjBmMmYzODdlYTIzZjBmZWFjZWY4MzYwNDF-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

Quote toolchain SRPM and RPM path expansions in toolkit/scripts/toolchain/build_official_toolchain_rpms.sh so generated paths are passed as single shell arguments. This prevents word splitting and glob expansion when build directories or RPM metadata-derived names are used in the no-install toolchain build path.

###### Change Log
- Quote SRPM path, output directory, log path, and spec path expansions in build_rpm_in_chroot_no_install.
- Parse rpmspec --builtrpms output into a Bash array and pass RPM names as array elements instead of relying on unquoted word splitting.
- Quote the SRPM path used by chroot_and_run_rpmbuild.

###### Test Methodology
- bash -n toolkit/scripts/toolchain/build_official_toolchain_rpms.sh
- git diff --check

###### Merge Checklist
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add the cbl-mariner-multi-package-reviewers team as reviewer
- [x] Ready to merge

---

###### Does this affect the toolchain?
**YES**

###### Associated issues
- N/A

###### Links to CVEs
- N/A

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/42473bb9-21d9-45f0-893a-1d75ffcaebe2)

Comment @datadog to request changes