### PR TITLE
Quote rspec tarball helper variables

### DIFF
--- a/SPECS-EXTENDED/rubygem-rspec-expectations/rspec-related-create-full-tarball.sh
+++ b/SPECS-EXTENDED/rubygem-rspec-expectations/rspec-related-create-full-tarball.sh
@@ -12,16 +12,16 @@ set -e
 CURRDIR=$(pwd)
 
 TMPDIRPATH=$(mktemp -d /var/tmp/rspec-tar-XXXXXX)
-pushd $TMPDIRPATH
+pushd "$TMPDIRPATH"
 
-git clone https://github.com/rspec/$1.git
-pushd $1
-git reset --hard v$2
+git clone "https://github.com/rspec/$1.git"
+pushd "$1"
+git reset --hard "v$2"
 popd
 
-ln -sf $1 $1-$2
-tar czf ${CURRDIR}/rubygem-$1-$2-full.tar.gz $1-$2/./
+ln -sf "$1" "$1-$2"
+tar czf "${CURRDIR}/rubygem-$1-$2-full.tar.gz" "$1-$2/./"
 
 popd
 
-rm -rf $TMPDIRPATH
+rm -rf "$TMPDIRPATH"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"1a4e8971-2dcd-4372-97c7-8115c4a4c5bc","source":"chat","resourceId":"cc4a20c3-c595-4ab0-b3f2-5a3f2a9fd14c","workflowId":"cc310b2c-d2da-40be-b406-6a67ca333137","codeChangeId":"cc310b2c-d2da-40be-b406-6a67ca333137","sourceType":"code_security_sast"} -->
###### Motivation

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/002a807d0d7eb77a7675d41f5fca28a9?panel_event_id=AwAAAZ_hkN_9WtHh9QAAABhBWl9oa05fOUFBQlkyOV9lTUZYWnZfenEAAAAkMTE5ZmUxOTAtZjdkMS00N2FiLWJjOGEtYWEyMDE4ODM2OGJiAAAAfA&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22MDAyYTgwN2QwZDdlYjc3YTc2NzVkNDFmNWZjYTI4YTl-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

The SAST finding reported an unquoted variable expansion in the rspec expectations tarball helper. The reported cleanup path is produced by mktemp, but the same helper also used unquoted positional arguments while building command arguments and paths. Quoting those expansions prevents word splitting and glob expansion without changing the generated tarball recipe.

###### Changes
- Quote TMPDIRPATH cleanup and directory navigation in SPECS-EXTENDED/rubygem-rspec-expectations/rspec-related-create-full-tarball.sh.
- Quote rspec package name, version, output archive, and tar input path expansions in the same helper.

###### Testing
- bash -n SPECS-EXTENDED/rubygem-rspec-expectations/rspec-related-create-full-tarball.sh
- shellcheck was not installed in the environment.
- Full helper execution was not run because it performs a GitHub clone.

###### Merge Checklist
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add @microsoft/cbl-mariner-multi-package-reviewers team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Summary
Quotes shell variable expansions in the rspec expectations tarball helper so generated paths and command arguments are not subject to word splitting or glob expansion.

###### Change Log
- Quote TMPDIRPATH in pushd and rm -rf calls.
- Quote rspec package and version expansions in git, pushd, ln, and tar calls.
- Preserve the existing tarball output name and source checkout behavior.

###### Does this affect the toolchain?
**NO**

###### Test Methodology
- bash -n SPECS-EXTENDED/rubygem-rspec-expectations/rspec-related-create-full-tarball.sh
- shellcheck was not installed in the environment.
- Full helper execution was not run because it performs a GitHub clone.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/cc4a20c3-c595-4ab0-b3f2-5a3f2a9fd14c)

Comment @datadog to request changes