### PR TITLE
Quote nodejs tarball script paths

### DIFF
--- a/SPECS/nodejs/generate_source_tarball.sh
+++ b/SPECS/nodejs/generate_source_tarball.sh
@@ -27,8 +27,8 @@ PARAMS=""
 while (( "$#" )); do
     case "$1" in
         --srcTarball)
-        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
-            SRC_TARBALL=$2
+        if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
+            SRC_TARBALL="$2"
             shift 2
         else
             echo "Error: Argument for $1 is missing" >&2
@@ -36,8 +36,8 @@ while (( "$#" )); do
         fi
         ;;
         --outFolder)
-        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
-            OUT_FOLDER=$2
+        if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
+            OUT_FOLDER="$2"
             shift 2
         else
             echo "Error: Argument for $1 is missing" >&2
@@ -45,8 +45,8 @@ while (( "$#" )); do
         fi
         ;;
         --pkgVersion)
-        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
-            PKG_VERSION=$2
+        if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
+            PKG_VERSION="$2"
             shift 2
         else
             echo "Error: Argument for $1 is missing" >&2
@@ -77,31 +77,31 @@ echo "-- create temp folder"
 tmpdir=$(mktemp -d)
 function cleanup {
     echo "+++ cleanup -> remove $tmpdir"
-    rm -rf $tmpdir
+    rm -rf "$tmpdir"
 }
 trap cleanup EXIT
 
-pushd $tmpdir > /dev/null
+pushd "$tmpdir" > /dev/null
 
 namever="node-v${PKG_VERSION}"
 
-if [[ -n $SRC_TARBALL ]]; then
+if [[ -n "$SRC_TARBALL" ]]; then
     upstream_tarball_name="$SRC_TARBALL"
-    clean_tarball_name="$OUT_FOLDER/$(basename $SRC_TARBALL)"
+    clean_tarball_name="$OUT_FOLDER/$(basename "$SRC_TARBALL")"
 else
     upstream_tarball_name="${namever}.tar.xz"
     clean_tarball_name="$OUT_FOLDER/${namever}-clean.tar.xz"
     download_url="https://nodejs.org/download/release/v${PKG_VERSION}/${upstream_tarball_name}"
 
     echo "Downloading upstream source tarball..."
-    curl -s -O $download_url
+    curl -s -O "$download_url"
 fi
 
 echo "Unpacking upstream source tarball..."
-tar -xf $upstream_tarball_name
+tar -xf "$upstream_tarball_name"
 
 echo "Removing bad vendored dependencies from source tree..."
-rm -rf ./$namever/deps/openssl/openssl
+rm -rf "./$namever/deps/openssl/openssl"
 
 # Create a reproducible tarball
 # Credit to https://reproducible-builds.org/docs/archives/ for instructions
@@ -111,7 +111,7 @@ echo "Repacking source tarball..."
 tar --sort=name --mtime="2021-11-10 00:00Z" \
     --owner=0 --group=0 --numeric-owner \
     --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
-    -cJf $clean_tarball_name ./$namever
+    -cJf "$clean_tarball_name" "./$namever"
 
 popd > /dev/null
 echo "Clean nodejs source tarball available at $clean_tarball_name"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"f95f3ef8-b61f-4465-983c-87a8c162cfbf","source":"chat","resourceId":"249de92a-6fad-4809-bf2f-ca47a635f6d3","workflowId":"502a49ca-5514-4e97-afa3-19f875003b4e","codeChangeId":"502a49ca-5514-4e97-afa3-19f875003b4e","sourceType":"code_security_sast"} -->
###### Summary

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/4abb9b14a9b00320b2ef3e3992a86c9d?panel_event_id=AwAAAZ_hkN_-oZaJsAAAABhBWl9oa05fLUFBQzBEVHhhQloydE9PZzgAAAAkMTE5ZmUxOTEtMTRhOS00OTE2LWJiY2UtNjRiYjZhOTg2MjA4AAAANQ&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22NGFiYjliMTRhOWIwMDMyMGIyZWYzZTM5OTJhODZjOWR-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

Quote shell expansions in SPECS/nodejs/generate_source_tarball.sh so user-provided tarball and output paths are passed to commands as single arguments. This addresses the high-severity SAST finding where tar could receive split or glob-expanded output and source path arguments.

###### Change Log
- Quote parameter value checks and assignments for source tarball, output folder, and package version inputs.
- Quote path and URL arguments passed to rm, pushd, basename, curl, and tar.
- Quote the repack tar output path and source tree argument at the reported finding.

###### Test Methodology
- bash -n SPECS/nodejs/generate_source_tarball.sh
- Ran a local source tarball regeneration using spaces in --srcTarball and --outFolder; confirmed the output tarball was created, vendored OpenSSL content was removed, and other content remained.
- git diff --check

---

###### Merge Checklist
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add @microsoft/cbl-mariner-multi-package-reviewers team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Does this affect the toolchain?
**NO**

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/249de92a-6fad-4809-bf2f-ca47a635f6d3)

Comment @datadog to request changes