### PR TITLE
Quote distroless USER_UID build arg

### DIFF
--- a/.pipelines/containerSourceData/scripts/BuildGoldenDistrolessContainer.sh
+++ b/.pipelines/containerSourceData/scripts/BuildGoldenDistrolessContainer.sh
@@ -37,7 +37,7 @@ function DockerBuild {
         --build-arg PACKAGES_TO_INSTALL="$packagesToInstall" \
         --build-arg PACKAGES_TO_HOLDBACK="$packagesToHoldback" \
         --build-arg USER="$user" \
-        --build-arg USER_UID=$userUid \
+        --build-arg USER_UID="$userUid" \
         --build-arg RPMS="$rpmsDir" \
         --build-arg LOCAL_REPO_FILE="$marinaraSrcDir/local.repo" \
         --no-cache


### PR DESCRIPTION
<!-- dd-meta {"pullId":"403b052f-f698-4fee-a185-a4868e8a93e2","source":"chat","resourceId":"83db2a6f-cc8a-4581-9f33-2cb93d6ab9ce","workflowId":"321dae71-568b-4e97-a22f-f4caba7f3f6c","codeChangeId":"321dae71-568b-4e97-a22f-f4caba7f3f6c","sourceType":"code_security_sast"} -->
###### Motivation

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/fa3485e9d55f381fe9aadebff2e66b17?panel_event_id=AwAAAZ_hkOAHAAQUGgAAABhBWl9oa09BSEFBRHFOVXJvaVVYdUctTnoAAAAkMTE5ZmUxOTAtZjdkMS00N2FiLWJjOGEtYWEyMDE4ODM2OGJiAAAAeQ&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22ZmEzNDg1ZTlkNTVmMzgxZmU5YWFkZWJmZjJlNjZiMTd-Nzk4NGVhYzZiYjA4YTJjOWJlODg4YjI1Y2RmY2QzZGY%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fcbl-mariner%22)

Quote the USER_UID Docker build argument in .pipelines/containerSourceData/scripts/BuildGoldenDistrolessContainer.sh to address the SAST finding for unquoted Bash variable expansion. Although userUid is currently assigned fixed numeric values inside DockerBuild, quoting the expansion prevents future word splitting or glob expansion if the value source changes.

###### Changes
- Quote the userUid expansion when passing USER_UID to docker build.

###### Testing
- bash -n .pipelines/containerSourceData/scripts/BuildGoldenDistrolessContainer.sh
- git diff --check

###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add @microsoft/cbl-mariner-multi-package-reviewers team as reviewer
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
Quotes the USER_UID Docker build argument in the distroless container build script. This removes the unquoted Bash variable expansion reported by SAST and keeps the argument handling consistent with neighboring Docker build args.

###### Change Log  <!-- REQUIRED -->
- Quoted the userUid expansion passed to the USER_UID Docker build argument.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Test Methodology
- bash -n .pipelines/containerSourceData/scripts/BuildGoldenDistrolessContainer.sh
- git diff --check

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/83db2a6f-cc8a-4581-9f33-2cb93d6ab9ce)

Comment @datadog to request changes