### PR TITLE
[SCRUM-40] Harden RabbitMQ vendor tarball inputs

### DIFF
--- a/SPECS/rabbitmq-server/generate-rabbitmq-server-tarball.sh
+++ b/SPECS/rabbitmq-server/generate-rabbitmq-server-tarball.sh
@@ -73,10 +73,9 @@ echo ""
 echo "[END] Retrieve all deps"
 
 # tar pulled dependencies
-tar -czf $VENDOR_TARBALL_NAME.tar.gz hex-$ELIXIR_HEX_VERSION.tar.gz *.tar
+tar -czf "$VENDOR_TARBALL_NAME.tar.gz" -- "hex-$ELIXIR_HEX_VERSION.tar.gz" "${HEX_PACKAGES[@]/%/.tar}"
 mv $VENDOR_TARBALL_NAME.tar.gz ../$VENDOR_TARBALL_NAME.tar.gz
 
 # Clean up files
 popd
 rm -r $TEMP_TARBALL_DIR
-


### PR DESCRIPTION
<!-- dd-meta {"pullId":"9153f9ec-c30e-4e49-a513-306c39b31e5d","source":"chat","resourceId":"30b055a7-54eb-4057-910f-d577e2924e1a","workflowId":"2469c421-5cf1-440d-b8ff-5ac7658cae5c","codeChangeId":"2469c421-5cf1-440d-b8ff-5ac7658cae5c","sourceType":"code_security_sast"} -->
###### Summary <!-- REQUIRED -->

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/16d4b97019e42dc3a025f63a8f6df62a?query=%40status%3Aopen%20-%40vulnerability.confidence%3Alow&column=score&order=desc&panel_event_id=AwAAAaBB-Zt5VV5qNQAAABhBYUJCLVp0NUFBQWdmRGpCLWpTQ09KQWIAAAAkZjFhMDQyMDQtYjU2MC00Mzk5LWJkNWQtYmMyNjhkMDY1MGRiAAA4oQ)

Fixes an option injection risk in the RabbitMQ vendor tarball generation script. The previous tar command archived `*.tar` directly, which could allow a filename beginning with `-` to be interpreted as a tar option.

###### Change Log  <!-- REQUIRED -->
- Updated SPECS/rabbitmq-server/generate-rabbitmq-server-tarball.sh to pass the expected package tarball names from the existing HEX_PACKAGES array instead of using a leading glob operand.
- Added `--` to the tar invocation so source archive operands cannot be parsed as options.

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Test Methodology
- Ran `bash -n SPECS/rabbitmq-server/generate-rabbitmq-server-tarball.sh`.
- Inspected the final tar invocation to confirm the vulnerable `*.tar` operand was removed.

###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add [@microsoft/cbl-mariner-multi-package-reviewers](https://github.com/orgs/microsoft/teams/cbl-mariner-multi-package-reviewers) team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/30b055a7-54eb-4057-910f-d577e2924e1a)